### PR TITLE
Automated Land Data Updates and Versioning Fixes

### DIFF
--- a/.github/workflows/update-lands.yml
+++ b/.github/workflows/update-lands.yml
@@ -1,0 +1,31 @@
+name: Update Lands Data
+
+on:
+  schedule:
+    - cron: '0 0 * * 1' # Runs at 00:00 every Monday
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  update-data:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Run update script
+        run: node scripts/update-lands.js
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/lands.json js/populator.js
+          git diff --quiet && git diff --staged --quiet || (git commit -m "Update lands data and version" && git push)

--- a/data/lands.json
+++ b/data/lands.json
@@ -1,7 +1,7 @@
 {
   "object": "list",
   "total_cards": 1130,
-  "version": "10",
+  "version": "10.01",
   "data": [
     {
       "object": "card",
@@ -25,7 +25,7 @@
       "edhrec_rank": 1,
       "is_basic": true,
       "prices": {
-        "usd": 0
+        "usd": "0.00"
       }
     },
     {
@@ -49,7 +49,7 @@
       "edhrec_rank": 2,
       "is_basic": true,
       "prices": {
-        "usd": 0
+        "usd": "0.00"
       }
     },
     {
@@ -74,7 +74,7 @@
       "edhrec_rank": 3,
       "is_basic": true,
       "prices": {
-        "usd": 0
+        "usd": "0.00"
       }
     },
     {
@@ -99,7 +99,7 @@
       "edhrec_rank": 4,
       "is_basic": true,
       "prices": {
-        "usd": 0
+        "usd": "0.00"
       }
     },
     {
@@ -124,7 +124,7 @@
       "edhrec_rank": 5,
       "is_basic": true,
       "prices": {
-        "usd": 0
+        "usd": "0.00"
       }
     },
     {
@@ -147,7 +147,7 @@
       "edhrec_rank": 6,
       "is_basic": true,
       "prices": {
-        "usd": 0
+        "usd": "0.00"
       }
     },
     {
@@ -172,11 +172,11 @@
       "produced_mana": [
         "W"
       ],
-      "edhrec_rank": 1961,
+      "edhrec_rank": 1644,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "6.52"
+        "usd": "7.19"
       }
     },
     {
@@ -218,10 +218,10 @@
       "artist_ids": [
         "c09ede88-a1b5-4a18-9895-dc8a965d28a5"
       ],
-      "edhrec_rank": 9345,
+      "edhrec_rank": 9303,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.27"
       }
     },
     {
@@ -264,10 +264,10 @@
       "artist_ids": [
         "b845b8ee-aeea-4822-bcf9-7230625ac95c"
       ],
-      "edhrec_rank": 21610,
+      "edhrec_rank": 21789,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.25"
       }
     },
     {
@@ -309,10 +309,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 2590,
+      "edhrec_rank": 2720,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.30"
       }
     },
     {
@@ -355,10 +355,10 @@
       "artist_ids": [
         "c6e77ba4-e891-4688-bca8-41b3f5f89dc6"
       ],
-      "edhrec_rank": 2157,
+      "edhrec_rank": 2096,
       "properties": [],
       "prices": {
-        "usd": "2.12"
+        "usd": "2.01"
       }
     },
     {
@@ -386,11 +386,11 @@
         "U",
         "W"
       ],
-      "edhrec_rank": 4611,
+      "edhrec_rank": 3861,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "4.18"
+        "usd": "3.69"
       }
     },
     {
@@ -431,10 +431,10 @@
         "1885e6cb-c827-4896-994e-3d0a027d602f",
         "44c3877f-8771-43dc-9e40-f4c765f59d2e"
       ],
-      "edhrec_rank": 500,
+      "edhrec_rank": 497,
       "properties": [],
       "prices": {
-        "usd": "8.53"
+        "usd": "8.33"
       }
     },
     {
@@ -472,10 +472,10 @@
       "artist_ids": [
         "bb677b1a-ce51-4888-83d6-5a94de461ff9"
       ],
-      "edhrec_rank": 576,
+      "edhrec_rank": 587,
       "properties": [],
       "prices": {
-        "usd": "0.47"
+        "usd": "0.43"
       }
     },
     {
@@ -512,10 +512,10 @@
       "artist_ids": [
         "a9065769-afcd-4e54-a3c0-5809e7b4108b"
       ],
-      "edhrec_rank": 2735,
+      "edhrec_rank": 2650,
       "properties": [],
       "prices": {
-        "usd": "0.94"
+        "usd": "0.82"
       }
     },
     {
@@ -555,10 +555,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 2177,
+      "edhrec_rank": 1987,
       "properties": [],
       "prices": {
-        "usd": "5.18"
+        "usd": "5.68"
       }
     },
     {
@@ -600,10 +600,10 @@
       "artist_ids": [
         "d29cd67f-30a7-4fb9-a081-36c3d5982442"
       ],
-      "edhrec_rank": 162,
+      "edhrec_rank": 159,
       "properties": [],
       "prices": {
-        "usd": "22.47"
+        "usd": "25.33"
       }
     },
     {
@@ -641,10 +641,10 @@
       "artist_ids": [
         "5d65ec8f-0c70-41f0-8585-5c91bd7f6f2e"
       ],
-      "edhrec_rank": 2000,
+      "edhrec_rank": 1805,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.30"
       }
     },
     {
@@ -678,10 +678,10 @@
       "artist_ids": [
         "c4e0aa7c-a008-4d71-80ce-d5a1ca0b251b"
       ],
-      "edhrec_rank": 21439,
+      "edhrec_rank": 21653,
       "properties": [],
       "prices": {
-        "usd": "10.68"
+        "usd": "11.80"
       }
     },
     {
@@ -740,10 +740,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 3174,
+      "edhrec_rank": 3212,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.30"
       }
     },
     {
@@ -810,10 +810,10 @@
       "artist_ids": [
         "9872f5c0-274a-48ce-a9ad-6f0d5654e29c"
       ],
-      "edhrec_rank": 969,
+      "edhrec_rank": 966,
       "properties": [],
       "prices": {
-        "usd": "25.60"
+        "usd": "28.35"
       }
     },
     {
@@ -838,11 +838,11 @@
       "produced_mana": [
         "U"
       ],
-      "edhrec_rank": 3747,
+      "edhrec_rank": 3219,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.93"
+        "usd": "1.38"
       }
     },
     {
@@ -869,7 +869,7 @@
         "R",
         "U"
       ],
-      "edhrec_rank": 8033,
+      "edhrec_rank": 7453,
       "is_basic": false,
       "properties": [],
       "prices": {
@@ -914,10 +914,10 @@
       "artist_ids": [
         "9c77c81a-3b3f-4e94-a834-327d01cd6b35"
       ],
-      "edhrec_rank": 3493,
+      "edhrec_rank": 3582,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.34"
       }
     },
     {
@@ -988,10 +988,10 @@
       "artist_ids": [
         "0fad2c48-a56e-4a0b-b512-224f6f238f20"
       ],
-      "edhrec_rank": 12395,
+      "edhrec_rank": 12467,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.17"
       }
     },
     {
@@ -1032,10 +1032,10 @@
       "artist_ids": [
         "f852fa13-137e-40f2-bbc1-0f01df09c0e0"
       ],
-      "edhrec_rank": 1159,
+      "edhrec_rank": 1108,
       "properties": [],
       "prices": {
-        "usd": "3.15"
+        "usd": "4.14"
       }
     },
     {
@@ -1077,10 +1077,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 8027,
+      "edhrec_rank": 7829,
       "properties": [],
       "prices": {
-        "usd": "1.04"
+        "usd": "0.69"
       }
     },
     {
@@ -1122,10 +1122,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 3921,
+      "edhrec_rank": 4102,
       "properties": [],
       "prices": {
-        "usd": "1.13"
+        "usd": "0.35"
       }
     },
     {
@@ -1182,10 +1182,10 @@
       "artist_ids": [
         "bb2a9339-bbe4-445f-9736-3c43379ee076"
       ],
-      "edhrec_rank": 2690,
+      "edhrec_rank": 2600,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.35"
       }
     },
     {
@@ -1230,10 +1230,10 @@
       "artist_ids": [
         "5a5ee217-9d28-419a-b92a-a2376c7d18b3"
       ],
-      "edhrec_rank": 25922,
+      "edhrec_rank": 26200,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.28"
       }
     },
     {
@@ -1275,10 +1275,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 11292,
+      "edhrec_rank": 11357,
       "properties": [],
       "prices": {
-        "usd": "0.53"
+        "usd": "0.62"
       }
     },
     {
@@ -1318,10 +1318,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 526,
+      "edhrec_rank": 518,
       "properties": [],
       "prices": {
-        "usd": "2.22"
+        "usd": "2.47"
       }
     },
     {
@@ -1364,7 +1364,7 @@
       "artist_ids": [
         "b4117364-73af-47e5-8cf0-901eeea09e01"
       ],
-      "edhrec_rank": 20117,
+      "edhrec_rank": 20370,
       "properties": [],
       "prices": {
         "usd": "0.21"
@@ -1408,7 +1408,7 @@
       "edhrec_rank": 64,
       "properties": [],
       "prices": {
-        "usd": "123.18"
+        "usd": "126.51"
       }
     },
     {
@@ -1450,10 +1450,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 2839,
+      "edhrec_rank": 2730,
       "properties": [],
       "prices": {
-        "usd": "2.68"
+        "usd": "2.43"
       }
     },
     {
@@ -1491,10 +1491,10 @@
       "artist_ids": [
         "bb677b1a-ce51-4888-83d6-5a94de461ff9"
       ],
-      "edhrec_rank": 3611,
+      "edhrec_rank": 3654,
       "properties": [],
       "prices": {
-        "usd": "2.50"
+        "usd": "3.49"
       }
     },
     {
@@ -1531,10 +1531,10 @@
       "artist_ids": [
         "9c3e9d17-509f-485c-9360-46d897ce716b"
       ],
-      "edhrec_rank": 1155,
+      "edhrec_rank": 1096,
       "properties": [],
       "prices": {
-        "usd": "8.16"
+        "usd": "7.48"
       }
     },
     {
@@ -1578,10 +1578,10 @@
       "artist_ids": [
         "6ac24c4b-70e9-4286-8f4b-b40c92ab5847"
       ],
-      "edhrec_rank": 334,
+      "edhrec_rank": 340,
       "properties": [],
       "prices": {
-        "usd": "0.58"
+        "usd": "0.61"
       }
     },
     {
@@ -1636,10 +1636,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 2391,
+      "edhrec_rank": 2457,
       "properties": [],
       "prices": {
-        "usd": "0.42"
+        "usd": "0.41"
       }
     },
     {
@@ -1681,7 +1681,7 @@
       "artist_ids": [
         "b4117364-73af-47e5-8cf0-901eeea09e01"
       ],
-      "edhrec_rank": 17230,
+      "edhrec_rank": 17337,
       "properties": [],
       "prices": {
         "usd": "0.40"
@@ -1725,10 +1725,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 8977,
+      "edhrec_rank": 9019,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.12"
       }
     },
     {
@@ -1767,10 +1767,10 @@
       "artist_ids": [
         "f8e7f8d6-6dde-4059-973c-30f1fd1bbe4e"
       ],
-      "edhrec_rank": 965,
+      "edhrec_rank": 936,
       "properties": [],
       "prices": {
-        "usd": "0.82"
+        "usd": "0.67"
       }
     },
     {
@@ -1812,10 +1812,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 13036,
+      "edhrec_rank": 13271,
       "properties": [],
       "prices": {
-        "usd": "1.81"
+        "usd": "1.86"
       }
     },
     {
@@ -1857,10 +1857,10 @@
       "artist_ids": [
         "bb677b1a-ce51-4888-83d6-5a94de461ff9"
       ],
-      "edhrec_rank": 3437,
+      "edhrec_rank": 3599,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.36"
       }
     },
     {
@@ -1896,10 +1896,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 8802,
+      "edhrec_rank": 8835,
       "properties": [],
       "prices": {
-        "usd": "7.95"
+        "usd": "8.29"
       }
     },
     {
@@ -1938,10 +1938,10 @@
       "artist_ids": [
         "05a3ac12-b25d-48e2-af5e-8a299fd3da14"
       ],
-      "edhrec_rank": 408,
+      "edhrec_rank": 388,
       "properties": [],
       "prices": {
-        "usd": "10.57"
+        "usd": "9.50"
       }
     },
     {
@@ -2012,10 +2012,10 @@
       "artist_ids": [
         "c09ede88-a1b5-4a18-9895-dc8a965d28a5"
       ],
-      "edhrec_rank": 3364,
+      "edhrec_rank": 3522,
       "properties": [],
       "prices": {
-        "usd": "1.29"
+        "usd": "1.70"
       }
     },
     {
@@ -2054,10 +2054,10 @@
       "artist_ids": [
         "39fcaaac-bf5d-4c43-ae20-4cf4921a44fa"
       ],
-      "edhrec_rank": 1423,
+      "edhrec_rank": 1454,
       "properties": [],
       "prices": {
-        "usd": "0.55"
+        "usd": "0.48"
       }
     },
     {
@@ -2091,10 +2091,10 @@
       "artist_ids": [
         "e956bacc-077d-4c12-b6bc-ba798b718af9"
       ],
-      "edhrec_rank": 54,
+      "edhrec_rank": 55,
       "properties": [],
       "prices": {
-        "usd": "32.85"
+        "usd": "37.09"
       }
     },
     {
@@ -2136,10 +2136,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 187,
+      "edhrec_rank": 191,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.25"
       }
     },
     {
@@ -2181,10 +2181,10 @@
       "artist_ids": [
         "afc47cec-3ccc-404e-a8c6-4d83dd504271"
       ],
-      "edhrec_rank": 11066,
+      "edhrec_rank": 11039,
       "properties": [],
       "prices": {
-        "usd": "6.40"
+        "usd": "7.47"
       }
     },
     {
@@ -2241,10 +2241,10 @@
       "artist_ids": [
         "7f1868e3-325f-4df9-8f27-a381fed4f0fc"
       ],
-      "edhrec_rank": 4220,
+      "edhrec_rank": 4082,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.15"
       }
     },
     {
@@ -2284,10 +2284,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 3296,
+      "edhrec_rank": 3393,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.38"
       }
     },
     {
@@ -2332,10 +2332,10 @@
       "artist_ids": [
         "5a5ee217-9d28-419a-b92a-a2376c7d18b3"
       ],
-      "edhrec_rank": 26087,
+      "edhrec_rank": 26357,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.31"
       }
     },
     {
@@ -2377,10 +2377,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 425,
+      "edhrec_rank": 436,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.29"
       }
     },
     {
@@ -2423,10 +2423,10 @@
       "artist_ids": [
         "a8c4ef83-94ad-41c7-861f-95debea16868"
       ],
-      "edhrec_rank": 1935,
+      "edhrec_rank": 1993,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.12"
       }
     },
     {
@@ -2451,11 +2451,11 @@
       "produced_mana": [
         "G"
       ],
-      "edhrec_rank": 2356,
+      "edhrec_rank": 2027,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "4.25"
+        "usd": "5.73"
       }
     },
     {
@@ -2489,10 +2489,10 @@
       "artist_ids": [
         "eb55171c-2342-45f4-a503-2d5a75baf752"
       ],
-      "edhrec_rank": 6342,
+      "edhrec_rank": 6512,
       "properties": [],
       "prices": {
-        "usd": "2.23"
+        "usd": "1.60"
       }
     },
     {
@@ -2533,7 +2533,7 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 386,
+      "edhrec_rank": 387,
       "properties": [],
       "prices": {
         "usd": null
@@ -2603,10 +2603,10 @@
       "artist_ids": [
         "b4344292-387b-4aa0-8225-13f1fbe77808"
       ],
-      "edhrec_rank": 304,
+      "edhrec_rank": 317,
       "properties": [],
       "prices": {
-        "usd": "7.79"
+        "usd": "7.01"
       }
     },
     {
@@ -2677,10 +2677,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 7008,
+      "edhrec_rank": 6740,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.36"
       }
     },
     {
@@ -2723,10 +2723,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 2343,
+      "edhrec_rank": 2394,
       "properties": [],
       "prices": {
-        "usd": "3.54"
+        "usd": "3.71"
       }
     },
     {
@@ -2766,10 +2766,10 @@
       "artist_ids": [
         "c4e0aa7c-a008-4d71-80ce-d5a1ca0b251b"
       ],
-      "edhrec_rank": 17497,
+      "edhrec_rank": 17757,
       "properties": [],
       "prices": {
-        "usd": "3.79"
+        "usd": "4.31"
       }
     },
     {
@@ -2828,10 +2828,10 @@
       "artist_ids": [
         "0c066852-6fdb-42d0-aab9-db4038850da0"
       ],
-      "edhrec_rank": 12446,
+      "edhrec_rank": 12552,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.38"
       }
     },
     {
@@ -2869,10 +2869,10 @@
       "artist_ids": [
         "90332db2-aecb-4d79-917b-95cbeb8d0cb6"
       ],
-      "edhrec_rank": 4593,
+      "edhrec_rank": 4736,
       "properties": [],
       "prices": {
-        "usd": "0.47"
+        "usd": "0.42"
       }
     },
     {
@@ -2930,10 +2930,10 @@
       "artist_ids": [
         "a6fe588c-5328-4703-8f61-4c6d0e56592d"
       ],
-      "edhrec_rank": 1789,
+      "edhrec_rank": 1816,
       "properties": [],
       "prices": {
-        "usd": "1.51"
+        "usd": "1.78"
       }
     },
     {
@@ -2974,10 +2974,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 4781,
+      "edhrec_rank": 4823,
       "properties": [],
       "prices": {
-        "usd": "2.36"
+        "usd": "2.71"
       }
     },
     {
@@ -3044,10 +3044,10 @@
       "artist_ids": [
         "0fbd4798-76eb-46d5-a5d4-1e3a25870e34"
       ],
-      "edhrec_rank": 1056,
+      "edhrec_rank": 1073,
       "properties": [],
       "prices": {
-        "usd": "4.62"
+        "usd": "4.17"
       }
     },
     {
@@ -3089,7 +3089,7 @@
       "artist_ids": [
         "5f92512a-2da0-4d91-8aaf-ac8d2404d776"
       ],
-      "edhrec_rank": 5151,
+      "edhrec_rank": 4872,
       "properties": [],
       "prices": {
         "usd": "0.19"
@@ -3133,10 +3133,10 @@
       "artist_ids": [
         "4441fe52-9e41-40c1-9b74-8510426279ab"
       ],
-      "edhrec_rank": 938,
+      "edhrec_rank": 973,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.34"
       }
     },
     {
@@ -3195,10 +3195,10 @@
       "artist_ids": [
         "2c14303e-97a3-45fa-9bd8-59e5332a65f9"
       ],
-      "edhrec_rank": 10956,
+      "edhrec_rank": 10983,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.09"
       }
     },
     {
@@ -3236,10 +3236,10 @@
       "artist_ids": [
         "7f1868e3-325f-4df9-8f27-a381fed4f0fc"
       ],
-      "edhrec_rank": 2585,
+      "edhrec_rank": 2646,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.37"
       }
     },
     {
@@ -3284,7 +3284,7 @@
       "edhrec_rank": 123,
       "properties": [],
       "prices": {
-        "usd": "9.54"
+        "usd": "10.64"
       }
     },
     {
@@ -3325,7 +3325,7 @@
       "artist_ids": [
         "c011318e-8503-48c1-a990-46e50aff48a0"
       ],
-      "edhrec_rank": 433,
+      "edhrec_rank": 431,
       "properties": [],
       "prices": {
         "usd": null
@@ -3362,10 +3362,10 @@
       "artist_ids": [
         "14a1de4b-1237-4e7b-8868-b71e87c9a46e"
       ],
-      "edhrec_rank": 10545,
+      "edhrec_rank": 10543,
       "properties": [],
       "prices": {
-        "usd": "1782.66"
+        "usd": "1949.99"
       }
     },
     {
@@ -3432,10 +3432,10 @@
       "artist_ids": [
         "63b2909b-7102-49c5-8f9d-6116a1913308"
       ],
-      "edhrec_rank": 9193,
+      "edhrec_rank": 9151,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.19"
       }
     },
     {
@@ -3462,11 +3462,11 @@
         "U",
         "W"
       ],
-      "edhrec_rank": 10653,
+      "edhrec_rank": 8758,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.44"
+        "usd": "0.42"
       }
     },
     {
@@ -3525,10 +3525,10 @@
       "artist_ids": [
         "0c066852-6fdb-42d0-aab9-db4038850da0"
       ],
-      "edhrec_rank": 13778,
+      "edhrec_rank": 13847,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.32"
       }
     },
     {
@@ -3572,10 +3572,10 @@
       "artist_ids": [
         "8df4596a-1d88-4b6a-9ce8-5c8089c3946c"
       ],
-      "edhrec_rank": 2293,
+      "edhrec_rank": 2375,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.39"
       }
     },
     {
@@ -3646,10 +3646,10 @@
       "artist_ids": [
         "a5f8354a-8b51-4e59-96b2-0e3aeae4fa1d"
       ],
-      "edhrec_rank": 8533,
+      "edhrec_rank": 8558,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.13"
       }
     },
     {
@@ -3692,10 +3692,10 @@
       "artist_ids": [
         "8a5540a8-18c9-4fa9-802c-59d6866114d5"
       ],
-      "edhrec_rank": 1046,
+      "edhrec_rank": 1067,
       "properties": [],
       "prices": {
-        "usd": "1.96"
+        "usd": "2.62"
       }
     },
     {
@@ -3732,10 +3732,10 @@
       "artist_ids": [
         "b5f1bd34-abee-40c9-99f7-a6ee089fb30b"
       ],
-      "edhrec_rank": 1552,
+      "edhrec_rank": 1592,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.37"
       }
     },
     {
@@ -3774,10 +3774,10 @@
       "artist_ids": [
         "1761c216-72b5-4a9b-afee-ad47a00fe1ad"
       ],
-      "edhrec_rank": 5135,
+      "edhrec_rank": 5235,
       "properties": [],
       "prices": {
-        "usd": "1.40"
+        "usd": "1.63"
       }
     },
     {
@@ -3819,10 +3819,10 @@
       "artist_ids": [
         "adad79bf-cd52-456a-b170-740ed8bff0fc"
       ],
-      "edhrec_rank": 586,
+      "edhrec_rank": 568,
       "properties": [],
       "prices": {
-        "usd": "9.65"
+        "usd": "8.81"
       }
     },
     {
@@ -3864,10 +3864,10 @@
       "artist_ids": [
         "9ee9a9cc-c09e-486f-918b-69f80cbc4188"
       ],
-      "edhrec_rank": 1016,
+      "edhrec_rank": 912,
       "properties": [],
       "prices": {
-        "usd": "9.76"
+        "usd": "10.66"
       }
     },
     {
@@ -3909,10 +3909,10 @@
       "artist_ids": [
         "2ffd9e06-94af-44f5-bec6-06f781941a6c"
       ],
-      "edhrec_rank": 9567,
+      "edhrec_rank": 9483,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.21"
       }
     },
     {
@@ -3952,10 +3952,10 @@
       "artist_ids": [
         "d82b1138-76d3-49f7-9d8c-bc2e2d3e0b0a"
       ],
-      "edhrec_rank": 12925,
+      "edhrec_rank": 13191,
       "properties": [],
       "prices": {
-        "usd": "0.07"
+        "usd": "0.08"
       }
     },
     {
@@ -3995,10 +3995,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 11875,
+      "edhrec_rank": 12039,
       "properties": [],
       "prices": {
-        "usd": "0.08"
+        "usd": "0.13"
       }
     },
     {
@@ -4038,10 +4038,10 @@
       "artist_ids": [
         "269392ac-4c06-4650-98e2-d49a5a7f2371"
       ],
-      "edhrec_rank": 15848,
+      "edhrec_rank": 16089,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.19"
       }
     },
     {
@@ -4081,10 +4081,10 @@
       "artist_ids": [
         "f8e7f8d6-6dde-4059-973c-30f1fd1bbe4e"
       ],
-      "edhrec_rank": 7827,
+      "edhrec_rank": 7895,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.13"
       }
     },
     {
@@ -4123,10 +4123,10 @@
       "artist_ids": [
         "af42a44c-8ec3-47a7-9047-5d29ddad186d"
       ],
-      "edhrec_rank": 771,
+      "edhrec_rank": 822,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.37"
       }
     },
     {
@@ -4193,10 +4193,10 @@
       "artist_ids": [
         "e24bc1d0-446b-45e0-b215-89f581837aa4"
       ],
-      "edhrec_rank": 785,
+      "edhrec_rank": 813,
       "properties": [],
       "prices": {
-        "usd": "5.18"
+        "usd": "5.51"
       }
     },
     {
@@ -4233,10 +4233,10 @@
       "artist_ids": [
         "770b4e16-de76-49ed-949f-84e6d2e06d25"
       ],
-      "edhrec_rank": 2971,
+      "edhrec_rank": 3007,
       "properties": [],
       "prices": {
-        "usd": "3.00"
+        "usd": "2.87"
       }
     },
     {
@@ -4274,10 +4274,10 @@
       "artist_ids": [
         "996ad764-4ae0-4952-8bb5-5a75c9d68275"
       ],
-      "edhrec_rank": 15688,
+      "edhrec_rank": 15997,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.31"
       }
     },
     {
@@ -4319,10 +4319,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 72,
+      "edhrec_rank": 69,
       "properties": [],
       "prices": {
-        "usd": "20.90"
+        "usd": "20.58"
       }
     },
     {
@@ -4363,10 +4363,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 877,
+      "edhrec_rank": 893,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.19"
       }
     },
     {
@@ -4435,7 +4435,7 @@
       "artist_ids": [
         "c3004e2c-d372-4faa-90db-f1274e75ef41"
       ],
-      "edhrec_rank": 2654,
+      "edhrec_rank": 2620,
       "properties": [],
       "prices": {
         "usd": "0.32"
@@ -4475,7 +4475,7 @@
       "edhrec_rank": 43,
       "properties": [],
       "prices": {
-        "usd": "69.71"
+        "usd": "77.96"
       }
     },
     {
@@ -4517,10 +4517,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 1518,
+      "edhrec_rank": 1497,
       "properties": [],
       "prices": {
-        "usd": "1.31"
+        "usd": "2.00"
       }
     },
     {
@@ -4561,10 +4561,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 1044,
+      "edhrec_rank": 1062,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.16"
       }
     },
     {
@@ -4607,10 +4607,10 @@
       "artist_ids": [
         "770b4e16-de76-49ed-949f-84e6d2e06d25"
       ],
-      "edhrec_rank": 21387,
+      "edhrec_rank": 21598,
       "properties": [],
       "prices": {
-        "usd": "0.11"
+        "usd": "0.13"
       }
     },
     {
@@ -4679,10 +4679,10 @@
       "artist_ids": [
         "a5048cc7-438a-4378-98e4-da99b78e1db0"
       ],
-      "edhrec_rank": 695,
+      "edhrec_rank": 666,
       "properties": [],
       "prices": {
-        "usd": "0.97"
+        "usd": "0.89"
       }
     },
     {
@@ -4709,11 +4709,11 @@
         "B",
         "R"
       ],
-      "edhrec_rank": 9038,
+      "edhrec_rank": 8377,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.27"
       }
     },
     {
@@ -4752,10 +4752,10 @@
       "artist_ids": [
         "6dd06426-59fe-4b9c-aad5-6da8446a5c3d"
       ],
-      "edhrec_rank": 27,
+      "edhrec_rank": 25,
       "properties": [],
       "prices": {
-        "usd": "1.51"
+        "usd": "2.07"
       }
     },
     {
@@ -4793,10 +4793,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 544,
+      "edhrec_rank": 548,
       "properties": [],
       "prices": {
-        "usd": "0.68"
+        "usd": "0.72"
       }
     },
     {
@@ -4838,10 +4838,10 @@
       "artist_ids": [
         "4441fe52-9e41-40c1-9b74-8510426279ab"
       ],
-      "edhrec_rank": 11390,
+      "edhrec_rank": 11613,
       "properties": [],
       "prices": {
-        "usd": "0.74"
+        "usd": "0.92"
       }
     },
     {
@@ -4883,10 +4883,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 440,
+      "edhrec_rank": 461,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.37"
       }
     },
     {
@@ -4929,10 +4929,10 @@
       "artist_ids": [
         "81995d11-da98-4f8b-89bd-b88ca2ddb06b"
       ],
-      "edhrec_rank": 1688,
+      "edhrec_rank": 1739,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.11"
       }
     },
     {
@@ -4976,7 +4976,7 @@
       "edhrec_rank": 77,
       "properties": [],
       "prices": {
-        "usd": "48.65"
+        "usd": "50.59"
       }
     },
     {
@@ -5013,10 +5013,10 @@
       "artist_ids": [
         "a51444a8-eb4b-4615-a663-d1d418591ccb"
       ],
-      "edhrec_rank": 2861,
+      "edhrec_rank": 2810,
       "properties": [],
       "prices": {
-        "usd": "14.14"
+        "usd": "17.22"
       }
     },
     {
@@ -5058,10 +5058,10 @@
       "artist_ids": [
         "8456c8ad-78c4-4ce0-9d5d-8a0cf994a361"
       ],
-      "edhrec_rank": 6592,
+      "edhrec_rank": 6829,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.23"
       }
     },
     {
@@ -5106,7 +5106,7 @@
       "edhrec_rank": 1660,
       "properties": [],
       "prices": {
-        "usd": "1.54"
+        "usd": "1.70"
       }
     },
     {
@@ -5145,10 +5145,10 @@
       "artist_ids": [
         "3130411f-ddd5-4cab-a2f4-0a9c3b95a26e"
       ],
-      "edhrec_rank": 15431,
+      "edhrec_rank": 15859,
       "properties": [],
       "prices": {
-        "usd": "1.30"
+        "usd": "1.39"
       }
     },
     {
@@ -5191,10 +5191,10 @@
       "artist_ids": [
         "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
       ],
-      "edhrec_rank": 1634,
+      "edhrec_rank": 1616,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.33"
       }
     },
     {
@@ -5236,10 +5236,10 @@
       "artist_ids": [
         "269392ac-4c06-4650-98e2-d49a5a7f2371"
       ],
-      "edhrec_rank": 205,
+      "edhrec_rank": 213,
       "properties": [],
       "prices": {
-        "usd": "17.94"
+        "usd": "17.85"
       }
     },
     {
@@ -5299,10 +5299,10 @@
       "artist_ids": [
         "bb677b1a-ce51-4888-83d6-5a94de461ff9"
       ],
-      "edhrec_rank": 7027,
+      "edhrec_rank": 7238,
       "properties": [],
       "prices": {
-        "usd": "0.08"
+        "usd": "0.18"
       }
     },
     {
@@ -5369,10 +5369,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 1102,
+      "edhrec_rank": 1131,
       "properties": [],
       "prices": {
-        "usd": "3.33"
+        "usd": "3.57"
       }
     },
     {
@@ -5417,7 +5417,7 @@
       "edhrec_rank": 63,
       "properties": [],
       "prices": {
-        "usd": "20.94"
+        "usd": "19.78"
       }
     },
     {
@@ -5473,10 +5473,10 @@
       "artist_ids": [
         "269392ac-4c06-4650-98e2-d49a5a7f2371"
       ],
-      "edhrec_rank": 9935,
+      "edhrec_rank": 10235,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.28"
       }
     },
     {
@@ -5545,10 +5545,10 @@
       "artist_ids": [
         "fce9030b-86bd-4439-b06a-920a1eeb184c"
       ],
-      "edhrec_rank": 730,
+      "edhrec_rank": 706,
       "properties": [],
       "prices": {
-        "usd": "0.67"
+        "usd": "0.61"
       }
     },
     {
@@ -5615,10 +5615,10 @@
       "artist_ids": [
         "3593dd7e-c547-4a32-81cd-7da725f60118"
       ],
-      "edhrec_rank": 738,
+      "edhrec_rank": 746,
       "properties": [],
       "prices": {
-        "usd": "4.74"
+        "usd": "5.81"
       }
     },
     {
@@ -5660,7 +5660,7 @@
       "artist_ids": [
         "92dfef2a-d0fa-42fd-bdd6-bc4c9286cb56"
       ],
-      "edhrec_rank": 3079,
+      "edhrec_rank": 3277,
       "properties": [],
       "prices": {
         "usd": "0.24"
@@ -5699,10 +5699,10 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 1231,
+      "edhrec_rank": 1271,
       "properties": [],
       "prices": {
-        "usd": "0.60"
+        "usd": "0.83"
       }
     },
     {
@@ -5745,7 +5745,7 @@
       "artist_ids": [
         "1be2b84d-99c5-4a51-b741-105cbeb53078"
       ],
-      "edhrec_rank": 4962,
+      "edhrec_rank": 4911,
       "properties": [],
       "prices": {
         "usd": "0.25"
@@ -5790,10 +5790,10 @@
       "artist_ids": [
         "c99a114b-c679-47df-a6e9-4f9d3ad5b114"
       ],
-      "edhrec_rank": 250,
+      "edhrec_rank": 241,
       "properties": [],
       "prices": {
-        "usd": "17.19"
+        "usd": "18.76"
       }
     },
     {
@@ -5835,10 +5835,10 @@
       "artist_ids": [
         "608e3b85-cdd3-4d1a-8a3a-7f1ed8856f6b"
       ],
-      "edhrec_rank": 13148,
+      "edhrec_rank": 13732,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.26"
       }
     },
     {
@@ -5876,10 +5876,10 @@
       "artist_ids": [
         "3a243c17-3baa-4b53-9599-645311cd7d3d"
       ],
-      "edhrec_rank": 195,
+      "edhrec_rank": 199,
       "properties": [],
       "prices": {
-        "usd": "0.55"
+        "usd": "0.56"
       }
     },
     {
@@ -5919,10 +5919,10 @@
       "artist_ids": [
         "b4117364-73af-47e5-8cf0-901eeea09e01"
       ],
-      "edhrec_rank": 186,
+      "edhrec_rank": 189,
       "properties": [],
       "prices": {
-        "usd": "30.10"
+        "usd": "31.67"
       }
     },
     {
@@ -5963,10 +5963,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 6195,
+      "edhrec_rank": 6392,
       "properties": [],
       "prices": {
-        "usd": "1.56"
+        "usd": "1.35"
       }
     },
     {
@@ -6007,10 +6007,10 @@
       "artist_ids": [
         "ad53afd6-d00f-4bc8-98ec-deab3f6aec50"
       ],
-      "edhrec_rank": 955,
+      "edhrec_rank": 969,
       "properties": [],
       "prices": {
-        "usd": "13.85"
+        "usd": "13.93"
       }
     },
     {
@@ -6046,10 +6046,10 @@
       "artist_ids": [
         "a662cb71-4770-4b49-8b03-2cf8497049a7"
       ],
-      "edhrec_rank": 927,
+      "edhrec_rank": 948,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.37"
       }
     },
     {
@@ -6090,10 +6090,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 3406,
+      "edhrec_rank": 3590,
       "properties": [],
       "prices": {
-        "usd": "5.10"
+        "usd": "5.22"
       }
     },
     {
@@ -6135,7 +6135,7 @@
       "artist_ids": [
         "262c8e55-4efc-467b-a042-6f734b9d2e01"
       ],
-      "edhrec_rank": 11116,
+      "edhrec_rank": 11247,
       "properties": [],
       "prices": {
         "usd": "0.24"
@@ -6180,10 +6180,10 @@
       "artist_ids": [
         "8a56d854-b424-45ec-9262-e993a382a961"
       ],
-      "edhrec_rank": 19442,
+      "edhrec_rank": 19763,
       "properties": [],
       "prices": {
-        "usd": "1.42"
+        "usd": "1.43"
       }
     },
     {
@@ -6225,10 +6225,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 102,
+      "edhrec_rank": 103,
       "properties": [],
       "prices": {
-        "usd": "0.44"
+        "usd": "0.45"
       }
     },
     {
@@ -6271,10 +6271,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 701,
+      "edhrec_rank": 702,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.35"
       }
     },
     {
@@ -6319,10 +6319,10 @@
       "artist_ids": [
         "6bd18163-aa22-4a41-82f6-8cdb8269d3c8"
       ],
-      "edhrec_rank": 4341,
+      "edhrec_rank": 4096,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.24"
       }
     },
     {
@@ -6364,10 +6364,10 @@
       "artist_ids": [
         "334dd388-1e26-4181-8eca-f9c097e29c5e"
       ],
-      "edhrec_rank": 5686,
+      "edhrec_rank": 5856,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.25"
       }
     },
     {
@@ -6410,10 +6410,10 @@
       "artist_ids": [
         "0330b5e8-2cf0-4ecb-8fd7-e20a18bdeb20"
       ],
-      "edhrec_rank": 325,
+      "edhrec_rank": 313,
       "properties": [],
       "prices": {
-        "usd": "5.47"
+        "usd": "6.25"
       }
     },
     {
@@ -6461,7 +6461,7 @@
       "edhrec_rank": 1173,
       "properties": [],
       "prices": {
-        "usd": "1.47"
+        "usd": "1.94"
       }
     },
     {
@@ -6517,10 +6517,10 @@
       "artist_ids": [
         "93bec3c0-0260-4d31-8064-5d01efb4153f"
       ],
-      "edhrec_rank": 675,
+      "edhrec_rank": 685,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.36"
       }
     },
     {
@@ -6560,10 +6560,10 @@
       "artist_ids": [
         "92f6c2c1-fa57-4b52-99c4-0fd866c13dc9"
       ],
-      "edhrec_rank": 1025,
+      "edhrec_rank": 1038,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.48"
       }
     },
     {
@@ -6603,10 +6603,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 709,
+      "edhrec_rank": 723,
       "properties": [],
       "prices": {
-        "usd": "6.65"
+        "usd": "7.50"
       }
     },
     {
@@ -6646,10 +6646,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 720,
+      "edhrec_rank": 737,
       "properties": [],
       "prices": {
-        "usd": "3.44"
+        "usd": "3.50"
       }
     },
     {
@@ -6694,10 +6694,10 @@
       "artist_ids": [
         "d54c4a1a-c0c5-4834-84db-125d341f3ad8"
       ],
-      "edhrec_rank": 25364,
+      "edhrec_rank": 25509,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.27"
       }
     },
     {
@@ -6739,10 +6739,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 915,
+      "edhrec_rank": 946,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.36"
       }
     },
     {
@@ -6776,10 +6776,10 @@
       "artist_ids": [
         "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
       ],
-      "edhrec_rank": 20454,
+      "edhrec_rank": 20631,
       "properties": [],
       "prices": {
-        "usd": "30.74"
+        "usd": "31.12"
       }
     },
     {
@@ -6818,10 +6818,10 @@
       "artist_ids": [
         "4b771085-c049-4308-930d-ec9665f803a4"
       ],
-      "edhrec_rank": 4843,
+      "edhrec_rank": 4857,
       "properties": [],
       "prices": {
-        "usd": "1.63"
+        "usd": "2.05"
       }
     },
     {
@@ -6863,10 +6863,10 @@
       "artist_ids": [
         "e45fe8d3-75d6-42c9-a2df-e945ad81ea27"
       ],
-      "edhrec_rank": 8911,
+      "edhrec_rank": 9062,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.24"
       }
     },
     {
@@ -6905,10 +6905,10 @@
       "artist_ids": [
         "3593dd7e-c547-4a32-81cd-7da725f60118"
       ],
-      "edhrec_rank": 7445,
+      "edhrec_rank": 7630,
       "properties": [],
       "prices": {
-        "usd": "1.11"
+        "usd": "0.40"
       }
     },
     {
@@ -6950,10 +6950,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 113,
+      "edhrec_rank": 112,
       "properties": [],
       "prices": {
-        "usd": "53.62"
+        "usd": "53.58"
       }
     },
     {
@@ -6991,10 +6991,10 @@
       "artist_ids": [
         "d4284188-36d3-4b24-b10f-80580ffdf52c"
       ],
-      "edhrec_rank": 13979,
+      "edhrec_rank": 14238,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.25"
       }
     },
     {
@@ -7036,10 +7036,10 @@
       "artist_ids": [
         "aa9f64d1-29e1-4c82-877e-44c18183f40b"
       ],
-      "edhrec_rank": 124,
+      "edhrec_rank": 125,
       "properties": [],
       "prices": {
-        "usd": "17.42"
+        "usd": "17.48"
       }
     },
     {
@@ -7080,10 +7080,10 @@
       "artist_ids": [
         "37970e22-9cee-44c1-af44-5ee27cf26b76"
       ],
-      "edhrec_rank": 5396,
+      "edhrec_rank": 5504,
       "properties": [],
       "prices": {
-        "usd": "0.97"
+        "usd": "0.94"
       }
     },
     {
@@ -7124,10 +7124,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 11704,
+      "edhrec_rank": 11837,
       "properties": [],
       "prices": {
-        "usd": "1.07"
+        "usd": "1.31"
       }
     },
     {
@@ -7168,10 +7168,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 852,
+      "edhrec_rank": 842,
       "properties": [],
       "prices": {
-        "usd": "2.61"
+        "usd": "2.92"
       }
     },
     {
@@ -7196,11 +7196,11 @@
       "produced_mana": [
         "G"
       ],
-      "edhrec_rank": 14466,
+      "edhrec_rank": 13532,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "8.77"
+        "usd": "8.97"
       }
     },
     {
@@ -7241,10 +7241,10 @@
       "artist_ids": [
         "d82b1138-76d3-49f7-9d8c-bc2e2d3e0b0a"
       ],
-      "edhrec_rank": 282,
+      "edhrec_rank": 289,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.41"
       }
     },
     {
@@ -7286,10 +7286,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 5952,
+      "edhrec_rank": 6076,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.09"
       }
     },
     {
@@ -7331,10 +7331,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 84,
+      "edhrec_rank": 85,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.32"
       }
     },
     {
@@ -7376,10 +7376,10 @@
       "artist_ids": [
         "a1685587-4b55-446b-b420-c37b202ed3f1"
       ],
-      "edhrec_rank": 22817,
+      "edhrec_rank": 23088,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.30"
       }
     },
     {
@@ -7423,7 +7423,7 @@
       "artist_ids": [
         "d084e74b-f63a-4107-b72c-ed6250ecc93b"
       ],
-      "edhrec_rank": 2723,
+      "edhrec_rank": 2826,
       "properties": [],
       "prices": {
         "usd": "1.33"
@@ -7467,10 +7467,10 @@
       "artist_ids": [
         "9ee9a9cc-c09e-486f-918b-69f80cbc4188"
       ],
-      "edhrec_rank": 101,
+      "edhrec_rank": 98,
       "properties": [],
       "prices": {
-        "usd": "620.22"
+        "usd": "789.99"
       }
     },
     {
@@ -7507,10 +7507,10 @@
       "artist_ids": [
         "c4e0aa7c-a008-4d71-80ce-d5a1ca0b251b"
       ],
-      "edhrec_rank": 16059,
+      "edhrec_rank": 16210,
       "properties": [],
       "prices": {
-        "usd": "53.98"
+        "usd": "63.38"
       }
     },
     {
@@ -7548,10 +7548,10 @@
       "artist_ids": [
         "f366a0ee-a0cd-466d-ba6a-90058c7a31a6"
       ],
-      "edhrec_rank": 1287,
+      "edhrec_rank": 1248,
       "properties": [],
       "prices": {
-        "usd": "477.75"
+        "usd": "521.77"
       }
     },
     {
@@ -7618,10 +7618,10 @@
       "artist_ids": [
         "e607a0d4-fc12-4c01-9e3f-501f5269b9cb"
       ],
-      "edhrec_rank": 727,
+      "edhrec_rank": 753,
       "properties": [],
       "prices": {
-        "usd": "4.82"
+        "usd": "4.23"
       }
     },
     {
@@ -7665,10 +7665,10 @@
       "artist_ids": [
         "760cf309-b4b6-43a2-b3a9-6f985f09e7db"
       ],
-      "edhrec_rank": 2717,
+      "edhrec_rank": 2823,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.36"
       }
     },
     {
@@ -7710,10 +7710,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 86,
+      "edhrec_rank": 84,
       "properties": [],
       "prices": {
-        "usd": "0.76"
+        "usd": "0.83"
       }
     },
     {
@@ -7752,10 +7752,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 5808,
+      "edhrec_rank": 5526,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.36"
       }
     },
     {
@@ -7797,10 +7797,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 22202,
+      "edhrec_rank": 22427,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.32"
       }
     },
     {
@@ -7838,10 +7838,10 @@
       "artist_ids": [
         "30fead7c-da53-4c1b-b514-4be6e5ce487c"
       ],
-      "edhrec_rank": 5326,
+      "edhrec_rank": 5347,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.27"
       }
     },
     {
@@ -7870,9 +7870,12 @@
         "R",
         "U"
       ],
-      "edhrec_rank": 22800,
+      "edhrec_rank": 11233,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "0.58"
+      }
     },
     {
       "object": "card",
@@ -7913,10 +7916,10 @@
       "artist_ids": [
         "b4117364-73af-47e5-8cf0-901eeea09e01"
       ],
-      "edhrec_rank": 11896,
+      "edhrec_rank": 12051,
       "properties": [],
       "prices": {
-        "usd": "6.06"
+        "usd": "3.11"
       }
     },
     {
@@ -7954,10 +7957,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 180,
+      "edhrec_rank": 182,
       "properties": [],
       "prices": {
-        "usd": "6.29"
+        "usd": "6.49"
       }
     },
     {
@@ -7997,10 +8000,10 @@
       "artist_ids": [
         "6cb0dc0c-4362-4c21-b23a-b2d7e096aa4f"
       ],
-      "edhrec_rank": 4210,
+      "edhrec_rank": 3943,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.26"
       }
     },
     {
@@ -8045,7 +8048,7 @@
       "edhrec_rank": 2,
       "properties": [],
       "prices": {
-        "usd": "0.72"
+        "usd": "0.90"
       }
     },
     {
@@ -8088,10 +8091,10 @@
       "artist_ids": [
         "7f1868e3-325f-4df9-8f27-a381fed4f0fc"
       ],
-      "edhrec_rank": 636,
+      "edhrec_rank": 644,
       "properties": [],
       "prices": {
-        "usd": "7.79"
+        "usd": "8.38"
       }
     },
     {
@@ -8133,10 +8136,10 @@
       "artist_ids": [
         "269392ac-4c06-4650-98e2-d49a5a7f2371"
       ],
-      "edhrec_rank": 1153,
+      "edhrec_rank": 1146,
       "properties": [],
       "prices": {
-        "usd": "0.95"
+        "usd": "1.25"
       }
     },
     {
@@ -8181,7 +8184,7 @@
       "artist_ids": [
         "39fcaaac-bf5d-4c43-ae20-4cf4921a44fa"
       ],
-      "edhrec_rank": 1924,
+      "edhrec_rank": 1960,
       "properties": [],
       "prices": {
         "usd": "0.30"
@@ -8243,10 +8246,10 @@
       "artist_ids": [
         "0c066852-6fdb-42d0-aab9-db4038850da0"
       ],
-      "edhrec_rank": 14526,
+      "edhrec_rank": 14760,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.34"
       }
     },
     {
@@ -8288,10 +8291,10 @@
       "artist_ids": [
         "adb9ad6d-6173-454b-8b50-a102b182548b"
       ],
-      "edhrec_rank": 2107,
+      "edhrec_rank": 2127,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.32"
       }
     },
     {
@@ -8334,10 +8337,10 @@
       "artist_ids": [
         "90332db2-aecb-4d79-917b-95cbeb8d0cb6"
       ],
-      "edhrec_rank": 2154,
+      "edhrec_rank": 2163,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.20"
       }
     },
     {
@@ -8379,10 +8382,10 @@
       "artist_ids": [
         "f009de11-3c8d-4663-b996-ca0c3e997fad"
       ],
-      "edhrec_rank": 9920,
+      "edhrec_rank": 10048,
       "properties": [],
       "prices": {
-        "usd": "0.77"
+        "usd": "0.76"
       }
     },
     {
@@ -8420,10 +8423,10 @@
       "artist_ids": [
         "9e048547-f9c3-4958-9c2c-91e45df7c6ae"
       ],
-      "edhrec_rank": 14467,
+      "edhrec_rank": 14555,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.26"
       }
     },
     {
@@ -8467,10 +8470,10 @@
         "1885e6cb-c827-4896-994e-3d0a027d602f",
         "44c3877f-8771-43dc-9e40-f4c765f59d2e"
       ],
-      "edhrec_rank": 1458,
+      "edhrec_rank": 1462,
       "properties": [],
       "prices": {
-        "usd": "1.60"
+        "usd": "1.68"
       }
     },
     {
@@ -8510,10 +8513,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 5545,
+      "edhrec_rank": 5698,
       "properties": [],
       "prices": {
-        "usd": "0.65"
+        "usd": "0.69"
       }
     },
     {
@@ -8554,10 +8557,10 @@
       "artist_ids": [
         "0c066852-6fdb-42d0-aab9-db4038850da0"
       ],
-      "edhrec_rank": 4061,
+      "edhrec_rank": 3871,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.46"
       }
     },
     {
@@ -8600,10 +8603,10 @@
       "artist_ids": [
         "89cc9475-dda2-4d13-bf88-54b92867a25c"
       ],
-      "edhrec_rank": 5321,
+      "edhrec_rank": 5362,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.12"
       }
     },
     {
@@ -8658,10 +8661,10 @@
       "artist_ids": [
         "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
       ],
-      "edhrec_rank": 8924,
+      "edhrec_rank": 8813,
       "properties": [],
       "prices": {
-        "usd": "0.08"
+        "usd": "0.27"
       }
     },
     {
@@ -8715,10 +8718,10 @@
       "artist_ids": [
         "81995d11-da98-4f8b-89bd-b88ca2ddb06b"
       ],
-      "edhrec_rank": 8330,
+      "edhrec_rank": 8646,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.14"
       }
     },
     {
@@ -8785,10 +8788,10 @@
       "artist_ids": [
         "d084e74b-f63a-4107-b72c-ed6250ecc93b"
       ],
-      "edhrec_rank": 1012,
+      "edhrec_rank": 1051,
       "properties": [],
       "prices": {
-        "usd": "2.96"
+        "usd": "3.53"
       }
     },
     {
@@ -8826,10 +8829,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 6102,
+      "edhrec_rank": 6242,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.37"
       }
     },
     {
@@ -8870,10 +8873,10 @@
       "artist_ids": [
         "af42a44c-8ec3-47a7-9047-5d29ddad186d"
       ],
-      "edhrec_rank": 2738,
+      "edhrec_rank": 2851,
       "properties": [],
       "prices": {
-        "usd": "0.76"
+        "usd": "0.72"
       }
     },
     {
@@ -8915,7 +8918,7 @@
       "artist_ids": [
         "669b8b90-758d-4f9e-b4f7-98cd6742eb97"
       ],
-      "edhrec_rank": 3445,
+      "edhrec_rank": 3655,
       "properties": [],
       "prices": {
         "usd": "0.23"
@@ -8961,10 +8964,10 @@
       "artist_ids": [
         "b845b8ee-aeea-4822-bcf9-7230625ac95c"
       ],
-      "edhrec_rank": 8691,
+      "edhrec_rank": 8845,
       "properties": [],
       "prices": {
-        "usd": "1.25"
+        "usd": "1.37"
       }
     },
     {
@@ -9006,10 +9009,10 @@
       "artist_ids": [
         "e4631396-f0ce-41df-9d35-a7bd1da9d5a6"
       ],
-      "edhrec_rank": 3430,
+      "edhrec_rank": 3236,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.22"
       }
     },
     {
@@ -9051,10 +9054,10 @@
       "artist_ids": [
         "269392ac-4c06-4650-98e2-d49a5a7f2371"
       ],
-      "edhrec_rank": 3790,
+      "edhrec_rank": 3893,
       "properties": [],
       "prices": {
-        "usd": "0.67"
+        "usd": "0.72"
       }
     },
     {
@@ -9098,10 +9101,10 @@
       "artist_ids": [
         "8a5540a8-18c9-4fa9-802c-59d6866114d5"
       ],
-      "edhrec_rank": 348,
+      "edhrec_rank": 360,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.44"
       }
     },
     {
@@ -9143,10 +9146,10 @@
       "artist_ids": [
         "17bc7f55-958b-43f4-bb40-09746d05b3f9"
       ],
-      "edhrec_rank": 8918,
+      "edhrec_rank": 8737,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.24"
       }
     },
     {
@@ -9185,10 +9188,10 @@
       "artist_ids": [
         "af42a44c-8ec3-47a7-9047-5d29ddad186d"
       ],
-      "edhrec_rank": 1787,
+      "edhrec_rank": 1750,
       "properties": [],
       "prices": {
-        "usd": "7.20"
+        "usd": "3.72"
       }
     },
     {
@@ -9233,10 +9236,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 10689,
+      "edhrec_rank": 10813,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.14"
       }
     },
     {
@@ -9274,10 +9277,10 @@
       "artist_ids": [
         "4b149402-618d-4f54-9db8-788e4a5bce70"
       ],
-      "edhrec_rank": 4371,
+      "edhrec_rank": 4461,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.32"
       }
     },
     {
@@ -9318,10 +9321,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 10145,
+      "edhrec_rank": 10352,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.22"
       }
     },
     {
@@ -9365,10 +9368,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 2541,
+      "edhrec_rank": 2590,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.26"
       }
     },
     {
@@ -9417,10 +9420,10 @@
       "artist_ids": [
         "70c20ea3-5ad6-4082-a337-6e994ae5828e"
       ],
-      "edhrec_rank": 6063,
+      "edhrec_rank": 6051,
       "properties": [],
       "prices": {
-        "usd": "3.77"
+        "usd": "4.05"
       }
     },
     {
@@ -9457,10 +9460,10 @@
       "artist_ids": [
         "3130411f-ddd5-4cab-a2f4-0a9c3b95a26e"
       ],
-      "edhrec_rank": 1631,
+      "edhrec_rank": 1595,
       "properties": [],
       "prices": {
-        "usd": "8.27"
+        "usd": "10.29"
       }
     },
     {
@@ -9488,11 +9491,11 @@
         "U",
         "W"
       ],
-      "edhrec_rank": 4335,
+      "edhrec_rank": 4018,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.28"
       }
     },
     {
@@ -9534,10 +9537,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 1291,
+      "edhrec_rank": 1280,
       "properties": [],
       "prices": {
-        "usd": "2.14"
+        "usd": "1.53"
       }
     },
     {
@@ -9593,10 +9596,10 @@
       "artist_ids": [
         "63def22f-9b97-423f-8791-2c1be9f46619"
       ],
-      "edhrec_rank": 3851,
+      "edhrec_rank": 3666,
       "properties": [],
       "prices": {
-        "usd": "0.45"
+        "usd": "0.41"
       }
     },
     {
@@ -9639,10 +9642,10 @@
       "artist_ids": [
         "3a243c17-3baa-4b53-9599-645311cd7d3d"
       ],
-      "edhrec_rank": 10426,
+      "edhrec_rank": 10554,
       "properties": [],
       "prices": {
-        "usd": "0.68"
+        "usd": "0.80"
       }
     },
     {
@@ -9692,10 +9695,10 @@
       "artist_ids": [
         "018799f5-76d7-4849-9375-f1b9030977e6"
       ],
-      "edhrec_rank": 1347,
+      "edhrec_rank": 1373,
       "properties": [],
       "prices": {
-        "usd": "7.66"
+        "usd": "8.05"
       }
     },
     {
@@ -9762,10 +9765,10 @@
       "artist_ids": [
         "3593dd7e-c547-4a32-81cd-7da725f60118"
       ],
-      "edhrec_rank": 1109,
+      "edhrec_rank": 1113,
       "properties": [],
       "prices": {
-        "usd": "5.57"
+        "usd": "6.45"
       }
     },
     {
@@ -9809,7 +9812,7 @@
       "artist_ids": [
         "c7c15d49-f84b-4d98-9a34-e80e8347b756"
       ],
-      "edhrec_rank": 2490,
+      "edhrec_rank": 2518,
       "properties": [],
       "prices": {
         "usd": "0.32"
@@ -9855,10 +9858,10 @@
       "artist_ids": [
         "507c67d2-1514-40ab-b7cb-a9f3b96a08e8"
       ],
-      "edhrec_rank": 1328,
+      "edhrec_rank": 1366,
       "properties": [],
       "prices": {
-        "usd": "2.09"
+        "usd": "2.46"
       }
     },
     {
@@ -9898,10 +9901,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 288,
+      "edhrec_rank": 286,
       "properties": [],
       "prices": {
-        "usd": "5.22"
+        "usd": "4.26"
       }
     },
     {
@@ -9943,10 +9946,10 @@
       "artist_ids": [
         "a77227ad-26f9-40da-b0f2-664b5196cea0"
       ],
-      "edhrec_rank": 300,
+      "edhrec_rank": 312,
       "properties": [],
       "prices": {
-        "usd": "3.00"
+        "usd": "3.42"
       }
     },
     {
@@ -9985,10 +9988,10 @@
       "artist_ids": [
         "1952c90b-a5a7-4328-9f7c-e11064f59daf"
       ],
-      "edhrec_rank": 17806,
+      "edhrec_rank": 18130,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.23"
       }
     },
     {
@@ -10030,10 +10033,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 451,
+      "edhrec_rank": 399,
       "properties": [],
       "prices": {
-        "usd": "11.83"
+        "usd": "8.41"
       }
     },
     {
@@ -10076,10 +10079,10 @@
       "artist_ids": [
         "39cb50cf-0223-43c7-bd96-afb5f05c7e43"
       ],
-      "edhrec_rank": 2127,
+      "edhrec_rank": 2092,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.20"
       }
     },
     {
@@ -10116,10 +10119,10 @@
       "artist_ids": [
         "bec9ba7f-594e-4ff0-8172-9ec1fc909607"
       ],
-      "edhrec_rank": 391,
+      "edhrec_rank": 396,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.43"
       }
     },
     {
@@ -10174,10 +10177,10 @@
       "artist_ids": [
         "3593dd7e-c547-4a32-81cd-7da725f60118"
       ],
-      "edhrec_rank": 3177,
+      "edhrec_rank": 3099,
       "properties": [],
       "prices": {
-        "usd": "1.61"
+        "usd": "2.02"
       }
     },
     {
@@ -10214,10 +10217,10 @@
       "artist_ids": [
         "c011318e-8503-48c1-a990-46e50aff48a0"
       ],
-      "edhrec_rank": 4365,
+      "edhrec_rank": 4590,
       "properties": [],
       "prices": {
-        "usd": "14.86"
+        "usd": "15.10"
       }
     },
     {
@@ -10258,10 +10261,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 2719,
+      "edhrec_rank": 2859,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.16"
       }
     },
     {
@@ -10302,10 +10305,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 4224,
+      "edhrec_rank": 4292,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.21"
       }
     },
     {
@@ -10346,10 +10349,10 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 3122,
+      "edhrec_rank": 3284,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.11"
       }
     },
     {
@@ -10390,10 +10393,10 @@
       "artist_ids": [
         "b8266529-1ffe-41e7-9969-fcf39f61426b"
       ],
-      "edhrec_rank": 3497,
+      "edhrec_rank": 3555,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.09"
       }
     },
     {
@@ -10434,10 +10437,10 @@
       "artist_ids": [
         "269392ac-4c06-4650-98e2-d49a5a7f2371"
       ],
-      "edhrec_rank": 2916,
+      "edhrec_rank": 3056,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.16"
       }
     },
     {
@@ -10479,10 +10482,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 274,
+      "edhrec_rank": 277,
       "properties": [],
       "prices": {
-        "usd": "5.09"
+        "usd": "4.97"
       }
     },
     {
@@ -10520,10 +10523,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 1758,
+      "edhrec_rank": 1715,
       "properties": [],
       "prices": {
-        "usd": "6.87"
+        "usd": "6.71"
       }
     },
     {
@@ -10564,10 +10567,10 @@
       "artist_ids": [
         "9e048547-f9c3-4958-9c2c-91e45df7c6ae"
       ],
-      "edhrec_rank": 2106,
+      "edhrec_rank": 2132,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.29"
       }
     },
     {
@@ -10609,10 +10612,10 @@
       "artist_ids": [
         "b00454a0-1b04-4f2f-9f63-1ce17aee0210"
       ],
-      "edhrec_rank": 1034,
+      "edhrec_rank": 960,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.40"
       }
     },
     {
@@ -10650,10 +10653,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 3511,
+      "edhrec_rank": 3565,
       "properties": [],
       "prices": {
-        "usd": "2.28"
+        "usd": "2.90"
       }
     },
     {
@@ -10690,10 +10693,10 @@
       "artist_ids": [
         "aabbf32e-5330-403a-8a99-a653c050e263"
       ],
-      "edhrec_rank": 2862,
+      "edhrec_rank": 2960,
       "properties": [],
       "prices": {
-        "usd": "2.71"
+        "usd": "3.72"
       }
     },
     {
@@ -10727,10 +10730,10 @@
       "artist_ids": [
         "770b4e16-de76-49ed-949f-84e6d2e06d25"
       ],
-      "edhrec_rank": 17087,
+      "edhrec_rank": 17156,
       "properties": [],
       "prices": {
-        "usd": "695.00"
+        "usd": "693.33"
       }
     },
     {
@@ -10757,11 +10760,11 @@
         "R",
         "W"
       ],
-      "edhrec_rank": 18497,
+      "edhrec_rank": 15314,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.12"
       }
     },
     {
@@ -10803,10 +10806,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 324,
+      "edhrec_rank": 339,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.37"
       }
     },
     {
@@ -10849,10 +10852,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 1650,
+      "edhrec_rank": 1706,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.14"
       }
     },
     {
@@ -10911,10 +10914,10 @@
       "artist_ids": [
         "0c066852-6fdb-42d0-aab9-db4038850da0"
       ],
-      "edhrec_rank": 14772,
+      "edhrec_rank": 15034,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.33"
       }
     },
     {
@@ -10983,10 +10986,10 @@
       "artist_ids": [
         "76bc57c7-47c6-40c5-8797-8ffcce430ac7"
       ],
-      "edhrec_rank": 529,
+      "edhrec_rank": 494,
       "properties": [],
       "prices": {
-        "usd": "1.46"
+        "usd": "1.82"
       }
     },
     {
@@ -11027,10 +11030,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 923,
+      "edhrec_rank": 953,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.19"
       }
     },
     {
@@ -11070,10 +11073,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 9119,
+      "edhrec_rank": 9182,
       "properties": [],
       "prices": {
-        "usd": "0.60"
+        "usd": "0.64"
       }
     },
     {
@@ -11114,10 +11117,10 @@
       "artist_ids": [
         "be1fa767-c905-49b1-afcf-77a8e9ebbd31"
       ],
-      "edhrec_rank": 88,
+      "edhrec_rank": 87,
       "properties": [],
       "prices": {
-        "usd": "1.54"
+        "usd": "1.52"
       }
     },
     {
@@ -11155,10 +11158,10 @@
       "artist_ids": [
         "bc760b5e-6f98-4a17-9b12-5f4eccd12bb2"
       ],
-      "edhrec_rank": 4807,
+      "edhrec_rank": 4999,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.42"
       }
     },
     {
@@ -11196,10 +11199,10 @@
       "artist_ids": [
         "02e2b5de-4341-464c-8fdb-a1adbf873bc0"
       ],
-      "edhrec_rank": 11179,
+      "edhrec_rank": 11450,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.29"
       }
     },
     {
@@ -11241,10 +11244,10 @@
       "artist_ids": [
         "21ed6499-c4d3-4965-ab02-6c7228275bec"
       ],
-      "edhrec_rank": 9309,
+      "edhrec_rank": 9496,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.23"
       }
     },
     {
@@ -11286,10 +11289,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 185,
+      "edhrec_rank": 181,
       "properties": [],
       "prices": {
-        "usd": "0.94"
+        "usd": "1.41"
       }
     },
     {
@@ -11330,10 +11333,10 @@
       "artist_ids": [
         "fc0fb0e9-aa30-4143-a43e-d20b4aa9d8ed"
       ],
-      "edhrec_rank": 4584,
+      "edhrec_rank": 4680,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.20"
       }
     },
     {
@@ -11376,10 +11379,10 @@
       "artist_ids": [
         "3a243c17-3baa-4b53-9599-645311cd7d3d"
       ],
-      "edhrec_rank": 8844,
+      "edhrec_rank": 9023,
       "properties": [],
       "prices": {
-        "usd": "0.57"
+        "usd": "0.58"
       }
     },
     {
@@ -11423,10 +11426,10 @@
       "artist_ids": [
         "c7c15d49-f84b-4d98-9a34-e80e8347b756"
       ],
-      "edhrec_rank": 2108,
+      "edhrec_rank": 2167,
       "properties": [],
       "prices": {
-        "usd": "1.00"
+        "usd": "1.22"
       }
     },
     {
@@ -11470,7 +11473,7 @@
       "edhrec_rank": 111,
       "properties": [],
       "prices": {
-        "usd": "1.86"
+        "usd": "1.99"
       }
     },
     {
@@ -11558,7 +11561,7 @@
       "artist_ids": [
         "a1bba8ff-63b4-4786-b1c4-f1bfe5d3ab1c"
       ],
-      "edhrec_rank": 5719,
+      "edhrec_rank": 5701,
       "properties": [],
       "prices": {
         "usd": "0.24"
@@ -11599,10 +11602,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 1993,
+      "edhrec_rank": 1977,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.17"
       }
     },
     {
@@ -11649,10 +11652,10 @@
       "artist_ids": [
         "c5562592-3387-495a-96fb-618a6a424a45"
       ],
-      "edhrec_rank": 774,
+      "edhrec_rank": 756,
       "properties": [],
       "prices": {
-        "usd": "4.48"
+        "usd": "5.82"
       }
     },
     {
@@ -11706,10 +11709,10 @@
       "artist_ids": [
         "7a9aaa63-73ae-492c-948e-7531415fdf31"
       ],
-      "edhrec_rank": 5006,
+      "edhrec_rank": 5329,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.28"
       }
     },
     {
@@ -11785,10 +11788,10 @@
       "artist_ids": [
         "a662cb71-4770-4b49-8b03-2cf8497049a7"
       ],
-      "edhrec_rank": 8507,
+      "edhrec_rank": 8633,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.29"
       }
     },
     {
@@ -11832,7 +11835,7 @@
       "artist_ids": [
         "30fead7c-da53-4c1b-b514-4be6e5ce487c"
       ],
-      "edhrec_rank": 11786,
+      "edhrec_rank": 11987,
       "properties": [],
       "prices": {
         "usd": "0.19"
@@ -11872,10 +11875,10 @@
       "artist_ids": [
         "f3116c88-57f4-4fd1-95f3-cfd163977661"
       ],
-      "edhrec_rank": 5028,
+      "edhrec_rank": 5116,
       "properties": [],
       "prices": {
-        "usd": "32.31"
+        "usd": "32.72"
       }
     },
     {
@@ -11914,10 +11917,10 @@
       "artist_ids": [
         "3130411f-ddd5-4cab-a2f4-0a9c3b95a26e"
       ],
-      "edhrec_rank": 16042,
+      "edhrec_rank": 16541,
       "properties": [],
       "prices": {
-        "usd": "1.32"
+        "usd": "1.38"
       }
     },
     {
@@ -11972,10 +11975,10 @@
       "artist_ids": [
         "85908891-3cc7-42b0-9b54-27ed0fe89c53"
       ],
-      "edhrec_rank": 3134,
+      "edhrec_rank": 3074,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.33"
       }
     },
     {
@@ -12014,10 +12017,10 @@
       "artist_ids": [
         "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
       ],
-      "edhrec_rank": 8317,
+      "edhrec_rank": 8335,
       "properties": [],
       "prices": {
-        "usd": "1.58"
+        "usd": "3.15"
       }
     },
     {
@@ -12056,10 +12059,10 @@
       "artist_ids": [
         "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
       ],
-      "edhrec_rank": 10551,
+      "edhrec_rank": 10571,
       "properties": [],
       "prices": {
-        "usd": "0.76"
+        "usd": "1.01"
       }
     },
     {
@@ -12097,10 +12100,10 @@
       "artist_ids": [
         "75b27b57-a475-449b-843d-15e33a39ec22"
       ],
-      "edhrec_rank": 2400,
+      "edhrec_rank": 2418,
       "properties": [],
       "prices": {
-        "usd": "0.54"
+        "usd": "1.00"
       }
     },
     {
@@ -12128,11 +12131,11 @@
         "U",
         "W"
       ],
-      "edhrec_rank": 4667,
+      "edhrec_rank": 4058,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.34"
       }
     },
     {
@@ -12159,9 +12162,12 @@
         "B",
         "W"
       ],
-      "edhrec_rank": 18064,
+      "edhrec_rank": 6594,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "2.68"
+      }
     },
     {
       "object": "card",
@@ -12200,10 +12206,10 @@
       "artist_ids": [
         "669b8b90-758d-4f9e-b4f7-98cd6742eb97"
       ],
-      "edhrec_rank": 4237,
+      "edhrec_rank": 4021,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.25"
       }
     },
     {
@@ -12244,10 +12250,10 @@
       "artist_ids": [
         "bb677b1a-ce51-4888-83d6-5a94de461ff9"
       ],
-      "edhrec_rank": 8910,
+      "edhrec_rank": 9250,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.27"
       }
     },
     {
@@ -12287,10 +12293,10 @@
       "artist_ids": [
         "62dc90c0-4bc2-4d42-ad76-59cad9243566"
       ],
-      "edhrec_rank": 3465,
+      "edhrec_rank": 3408,
       "properties": [],
       "prices": {
-        "usd": "12.71"
+        "usd": "13.37"
       }
     },
     {
@@ -12331,10 +12337,10 @@
       "artist_ids": [
         "7f1868e3-325f-4df9-8f27-a381fed4f0fc"
       ],
-      "edhrec_rank": 370,
+      "edhrec_rank": 376,
       "properties": [],
       "prices": {
-        "usd": "5.91"
+        "usd": "6.39"
       }
     },
     {
@@ -12372,10 +12378,10 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 1572,
+      "edhrec_rank": 1591,
       "properties": [],
       "prices": {
-        "usd": "4.15"
+        "usd": "4.18"
       }
     },
     {
@@ -12418,10 +12424,10 @@
       "artist_ids": [
         "bec9ba7f-594e-4ff0-8172-9ec1fc909607"
       ],
-      "edhrec_rank": 788,
+      "edhrec_rank": 776,
       "properties": [],
       "prices": {
-        "usd": "9.47"
+        "usd": "11.30"
       }
     },
     {
@@ -12458,10 +12464,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 21745,
+      "edhrec_rank": 21967,
       "properties": [],
       "prices": {
-        "usd": "290.66"
+        "usd": "292.66"
       }
     },
     {
@@ -12503,10 +12509,10 @@
       "artist_ids": [
         "54366fc1-c5b1-4faa-a7a5-de2abc119de1"
       ],
-      "edhrec_rank": 11060,
+      "edhrec_rank": 11178,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.30"
       }
     },
     {
@@ -12544,10 +12550,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 542,
+      "edhrec_rank": 541,
       "properties": [],
       "prices": {
-        "usd": "5.84"
+        "usd": "4.90"
       }
     },
     {
@@ -12586,10 +12592,10 @@
       "artist_ids": [
         "92f6c2c1-fa57-4b52-99c4-0fd866c13dc9"
       ],
-      "edhrec_rank": 1125,
+      "edhrec_rank": 1063,
       "properties": [],
       "prices": {
-        "usd": "27.01"
+        "usd": "21.59"
       }
     },
     {
@@ -12672,10 +12678,10 @@
       "artist_ids": [
         "20871267-2d8a-41d5-b03a-be3d557c5734"
       ],
-      "edhrec_rank": 2902,
+      "edhrec_rank": 2811,
       "properties": [],
       "prices": {
-        "usd": "2.69"
+        "usd": "5.56"
       }
     },
     {
@@ -12713,10 +12719,10 @@
       "artist_ids": [
         "81995d11-da98-4f8b-89bd-b88ca2ddb06b"
       ],
-      "edhrec_rank": 9972,
+      "edhrec_rank": 10202,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.27"
       }
     },
     {
@@ -12753,10 +12759,10 @@
       "artist_ids": [
         "81995d11-da98-4f8b-89bd-b88ca2ddb06b"
       ],
-      "edhrec_rank": 5792,
+      "edhrec_rank": 5954,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.36"
       }
     },
     {
@@ -12798,10 +12804,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 3423,
+      "edhrec_rank": 3529,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.27"
       }
     },
     {
@@ -12836,10 +12842,10 @@
       "artist_ids": [
         "f0c43e1b-1853-4abc-8a1b-d7dda6c1d592"
       ],
-      "edhrec_rank": 876,
+      "edhrec_rank": 848,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.22"
       }
     },
     {
@@ -12877,10 +12883,10 @@
       "artist_ids": [
         "3a243c17-3baa-4b53-9599-645311cd7d3d"
       ],
-      "edhrec_rank": 5624,
+      "edhrec_rank": 5855,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.35"
       }
     },
     {
@@ -12922,10 +12928,10 @@
       "artist_ids": [
         "a5048cc7-438a-4378-98e4-da99b78e1db0"
       ],
-      "edhrec_rank": 10669,
+      "edhrec_rank": 10616,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.16"
       }
     },
     {
@@ -12964,10 +12970,10 @@
       "artist_ids": [
         "76bc57c7-47c6-40c5-8797-8ffcce430ac7"
       ],
-      "edhrec_rank": 4870,
+      "edhrec_rank": 4547,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.42"
       }
     },
     {
@@ -13007,10 +13013,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 1394,
+      "edhrec_rank": 1219,
       "properties": [],
       "prices": {
-        "usd": "15.89"
+        "usd": "15.33"
       }
     },
     {
@@ -13050,10 +13056,10 @@
       "artist_ids": [
         "fc0fb0e9-aa30-4143-a43e-d20b4aa9d8ed"
       ],
-      "edhrec_rank": 10131,
+      "edhrec_rank": 10257,
       "properties": [],
       "prices": {
-        "usd": "2.26"
+        "usd": "1.95"
       }
     },
     {
@@ -13088,7 +13094,7 @@
       "artist_ids": [
         "f07d73b9-52a0-4fe5-858b-61f7b42174a5"
       ],
-      "edhrec_rank": 17,
+      "edhrec_rank": 18,
       "properties": [],
       "prices": {
         "usd": "0.18"
@@ -13136,7 +13142,7 @@
       "edhrec_rank": 9,
       "properties": [],
       "prices": {
-        "usd": "2.10"
+        "usd": "2.34"
       }
     },
     {
@@ -13171,10 +13177,10 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 2767,
+      "edhrec_rank": 2789,
       "properties": [],
       "prices": {
-        "usd": "58.74"
+        "usd": "63.32"
       }
     },
     {
@@ -13209,10 +13215,10 @@
       "artist_ids": [
         "6dd06426-59fe-4b9c-aad5-6da8446a5c3d"
       ],
-      "edhrec_rank": 60,
+      "edhrec_rank": 54,
       "properties": [],
       "prices": {
-        "usd": "4.42"
+        "usd": "2.62"
       }
     },
     {
@@ -13250,10 +13256,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 7413,
+      "edhrec_rank": 7598,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.36"
       }
     },
     {
@@ -13292,10 +13298,10 @@
       "artist_ids": [
         "289e552e-3b58-484f-a939-64a01426e84d"
       ],
-      "edhrec_rank": 4478,
+      "edhrec_rank": 4660,
       "properties": [],
       "prices": {
-        "usd": "1.48"
+        "usd": "1.56"
       }
     },
     {
@@ -13362,10 +13368,10 @@
       "artist_ids": [
         "f8e7f8d6-6dde-4059-973c-30f1fd1bbe4e"
       ],
-      "edhrec_rank": 230,
+      "edhrec_rank": 207,
       "properties": [],
       "prices": {
-        "usd": "3.67"
+        "usd": "3.30"
       }
     },
     {
@@ -13407,10 +13413,10 @@
       "artist_ids": [
         "e4631396-f0ce-41df-9d35-a7bd1da9d5a6"
       ],
-      "edhrec_rank": 816,
+      "edhrec_rank": 778,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.41"
       }
     },
     {
@@ -13449,10 +13455,10 @@
       "artist_ids": [
         "d084e74b-f63a-4107-b72c-ed6250ecc93b"
       ],
-      "edhrec_rank": 10233,
+      "edhrec_rank": 10299,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.16"
       }
     },
     {
@@ -13494,10 +13500,10 @@
       "artist_ids": [
         "878a38c8-617b-4c02-9b93-719c19413490"
       ],
-      "edhrec_rank": 4794,
+      "edhrec_rank": 4890,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.28"
       }
     },
     {
@@ -13540,10 +13546,10 @@
       "artist_ids": [
         "982d9460-f9b9-42f6-8a25-47afa7df22e9"
       ],
-      "edhrec_rank": 2858,
+      "edhrec_rank": 2302,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.35"
       }
     },
     {
@@ -13586,7 +13592,7 @@
       "artist_ids": [
         "e607a0d4-fc12-4c01-9e3f-501f5269b9cb"
       ],
-      "edhrec_rank": 378,
+      "edhrec_rank": 350,
       "properties": [],
       "prices": {
         "usd": "6.32"
@@ -13632,10 +13638,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 837,
+      "edhrec_rank": 861,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.35"
       }
     },
     {
@@ -13672,10 +13678,10 @@
       "artist_ids": [
         "ad53afd6-d00f-4bc8-98ec-deab3f6aec50"
       ],
-      "edhrec_rank": 819,
+      "edhrec_rank": 857,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.25"
       }
     },
     {
@@ -13728,10 +13734,10 @@
       "artist_ids": [
         "f366a0ee-a0cd-466d-ba6a-90058c7a31a6"
       ],
-      "edhrec_rank": 436,
+      "edhrec_rank": 448,
       "properties": [],
       "prices": {
-        "usd": "33.67"
+        "usd": "33.25"
       }
     },
     {
@@ -13760,9 +13766,12 @@
         "R",
         "W"
       ],
-      "edhrec_rank": 26840,
+      "edhrec_rank": 13102,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "0.21"
+      }
     },
     {
       "object": "card",
@@ -13803,10 +13812,10 @@
       "artist_ids": [
         "7b1b0ce9-2c58-4321-a2a7-cdc94feae082"
       ],
-      "edhrec_rank": 800,
+      "edhrec_rank": 816,
       "properties": [],
       "prices": {
-        "usd": "5.44"
+        "usd": "6.03"
       }
     },
     {
@@ -13831,11 +13840,11 @@
       "produced_mana": [
         "R"
       ],
-      "edhrec_rank": 2371,
+      "edhrec_rank": 2065,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "1.97"
+        "usd": "2.20"
       }
     },
     {
@@ -13878,10 +13887,10 @@
       "artist_ids": [
         "a51444a8-eb4b-4615-a663-d1d418591ccb"
       ],
-      "edhrec_rank": 1269,
+      "edhrec_rank": 1251,
       "properties": [],
       "prices": {
-        "usd": "9.37"
+        "usd": "9.38"
       }
     },
     {
@@ -13921,10 +13930,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 3128,
+      "edhrec_rank": 3200,
       "properties": [],
       "prices": {
-        "usd": "4.38"
+        "usd": "4.53"
       }
     },
     {
@@ -13963,10 +13972,10 @@
       "artist_ids": [
         "fce9030b-86bd-4439-b06a-920a1eeb184c"
       ],
-      "edhrec_rank": 3717,
+      "edhrec_rank": 3641,
       "properties": [],
       "prices": {
-        "usd": "1.89"
+        "usd": "1.84"
       }
     },
     {
@@ -14000,10 +14009,10 @@
       "artist_ids": [
         "3130411f-ddd5-4cab-a2f4-0a9c3b95a26e"
       ],
-      "edhrec_rank": 4986,
+      "edhrec_rank": 5179,
       "properties": [],
       "prices": {
-        "usd": "1.36"
+        "usd": "1.30"
       }
     },
     {
@@ -14046,10 +14055,10 @@
       "artist_ids": [
         "8a5540a8-18c9-4fa9-802c-59d6866114d5"
       ],
-      "edhrec_rank": 320,
+      "edhrec_rank": 309,
       "properties": [],
       "prices": {
-        "usd": "4.20"
+        "usd": "4.24"
       }
     },
     {
@@ -14083,10 +14092,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 41,
+      "edhrec_rank": 39,
       "properties": [],
       "prices": {
-        "usd": "91.01"
+        "usd": "109.94"
       }
     },
     {
@@ -14128,10 +14137,10 @@
       "artist_ids": [
         "a5048cc7-438a-4378-98e4-da99b78e1db0"
       ],
-      "edhrec_rank": 741,
+      "edhrec_rank": 714,
       "properties": [],
       "prices": {
-        "usd": "8.10"
+        "usd": "8.36"
       }
     },
     {
@@ -14158,11 +14167,11 @@
         "B",
         "G"
       ],
-      "edhrec_rank": 11084,
+      "edhrec_rank": 10103,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.21"
       }
     },
     {
@@ -14199,10 +14208,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 1619,
+      "edhrec_rank": 1641,
       "properties": [],
       "prices": {
-        "usd": "10.76"
+        "usd": "10.02"
       }
     },
     {
@@ -14229,11 +14238,11 @@
         "B",
         "W"
       ],
-      "edhrec_rank": 16610,
+      "edhrec_rank": 13910,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.11"
       }
     },
     {
@@ -14290,10 +14299,10 @@
       "artist_ids": [
         "fcd5ea36-64e0-4af0-992a-3c68a34a400f"
       ],
-      "edhrec_rank": 664,
+      "edhrec_rank": 688,
       "properties": [],
       "prices": {
-        "usd": "8.53"
+        "usd": "9.04"
       }
     },
     {
@@ -14332,10 +14341,10 @@
       "artist_ids": [
         "46dc4b5e-e42c-4d65-a4f3-ad75b0f6f6dd"
       ],
-      "edhrec_rank": 10490,
+      "edhrec_rank": 10680,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.44"
       }
     },
     {
@@ -14378,10 +14387,10 @@
       "artist_ids": [
         "39cb50cf-0223-43c7-bd96-afb5f05c7e43"
       ],
-      "edhrec_rank": 1672,
+      "edhrec_rank": 1650,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.27"
       }
     },
     {
@@ -14423,10 +14432,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 319,
+      "edhrec_rank": 326,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.40"
       }
     },
     {
@@ -14464,10 +14473,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 2132,
+      "edhrec_rank": 2169,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.30"
       }
     },
     {
@@ -14508,10 +14517,10 @@
       "artist_ids": [
         "1952c90b-a5a7-4328-9f7c-e11064f59daf"
       ],
-      "edhrec_rank": 795,
+      "edhrec_rank": 811,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.31"
       }
     },
     {
@@ -14554,10 +14563,10 @@
       "artist_ids": [
         "fa8fd324-099a-43f2-9c57-97f64e38a5e9"
       ],
-      "edhrec_rank": 13019,
+      "edhrec_rank": 13338,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.17"
       }
     },
     {
@@ -14599,10 +14608,10 @@
       "artist_ids": [
         "adb9ad6d-6173-454b-8b50-a102b182548b"
       ],
-      "edhrec_rank": 4729,
+      "edhrec_rank": 4841,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.26"
       }
     },
     {
@@ -14643,10 +14652,10 @@
       "artist_ids": [
         "4eac683c-8c96-4f57-b8a4-ad7f7b7c44c7"
       ],
-      "edhrec_rank": 22127,
+      "edhrec_rank": 22224,
       "properties": [],
       "prices": {
-        "usd": "7.05"
+        "usd": "10.31"
       }
     },
     {
@@ -14688,10 +14697,10 @@
       "artist_ids": [
         "d82b1138-76d3-49f7-9d8c-bc2e2d3e0b0a"
       ],
-      "edhrec_rank": 6016,
+      "edhrec_rank": 6145,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.23"
       }
     },
     {
@@ -14732,10 +14741,10 @@
       "artist_ids": [
         "c4c9b5ea-4b31-40a0-8e40-d7dfeae43234"
       ],
-      "edhrec_rank": 11902,
+      "edhrec_rank": 12168,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.24"
       }
     },
     {
@@ -14776,10 +14785,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 336,
+      "edhrec_rank": 342,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.33"
       }
     },
     {
@@ -14808,9 +14817,12 @@
         "B",
         "W"
       ],
-      "edhrec_rank": 24790,
+      "edhrec_rank": 12183,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "0.16"
+      }
     },
     {
       "object": "card",
@@ -14851,10 +14863,10 @@
       "artist_ids": [
         "269392ac-4c06-4650-98e2-d49a5a7f2371"
       ],
-      "edhrec_rank": 4934,
+      "edhrec_rank": 5062,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.18"
       }
     },
     {
@@ -14909,10 +14921,10 @@
       "artist_ids": [
         "1624a1a8-3492-4c0b-9abc-83dcf2653111"
       ],
-      "edhrec_rank": 15182,
+      "edhrec_rank": 15054,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.16"
       }
     },
     {
@@ -14966,10 +14978,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 9477,
+      "edhrec_rank": 9679,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.10"
       }
     },
     {
@@ -15008,10 +15020,10 @@
       "artist_ids": [
         "1675947d-e663-4200-a6ce-5ad7bb3c83b1"
       ],
-      "edhrec_rank": 19919,
+      "edhrec_rank": 20121,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.42"
       }
     },
     {
@@ -15073,10 +15085,10 @@
       "artist_ids": [
         "669b8b90-758d-4f9e-b4f7-98cd6742eb97"
       ],
-      "edhrec_rank": 1048,
+      "edhrec_rank": 993,
       "properties": [],
       "prices": {
-        "usd": "2.84"
+        "usd": "3.55"
       }
     },
     {
@@ -15121,10 +15133,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 381,
+      "edhrec_rank": 389,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.27"
       }
     },
     {
@@ -15166,10 +15178,10 @@
       "artist_ids": [
         "1431bdd4-c187-40ea-847a-e1dcd835598a"
       ],
-      "edhrec_rank": 11424,
+      "edhrec_rank": 11609,
       "properties": [],
       "prices": {
-        "usd": "0.82"
+        "usd": "0.78"
       }
     },
     {
@@ -15212,10 +15224,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 354,
+      "edhrec_rank": 344,
       "properties": [],
       "prices": {
-        "usd": "0.44"
+        "usd": "0.39"
       }
     },
     {
@@ -15252,10 +15264,10 @@
       "artist_ids": [
         "ebde5690-d401-46ba-8fd3-b9c07d5ef5a7"
       ],
-      "edhrec_rank": 9779,
+      "edhrec_rank": 9996,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.20"
       }
     },
     {
@@ -15297,10 +15309,10 @@
       "artist_ids": [
         "30fead7c-da53-4c1b-b514-4be6e5ce487c"
       ],
-      "edhrec_rank": 14779,
+      "edhrec_rank": 15035,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.25"
       }
     },
     {
@@ -15343,10 +15355,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 363,
+      "edhrec_rank": 349,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.36"
       }
     },
     {
@@ -15386,10 +15398,10 @@
       "artist_ids": [
         "48e2b98c-5467-4671-bd42-4c3746115117"
       ],
-      "edhrec_rank": 460,
+      "edhrec_rank": 452,
       "properties": [],
       "prices": {
-        "usd": "1327.93"
+        "usd": "1495.77"
       }
     },
     {
@@ -15433,10 +15445,10 @@
       "artist_ids": [
         "25645c87-71be-400b-8522-618a52c37454"
       ],
-      "edhrec_rank": 5308,
+      "edhrec_rank": 5471,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.30"
       }
     },
     {
@@ -15477,10 +15489,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 361,
+      "edhrec_rank": 367,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.34"
       }
     },
     {
@@ -15534,10 +15546,10 @@
       "artist_ids": [
         "db74e463-9c78-4f45-80a9-efa5cc4f9841"
       ],
-      "edhrec_rank": 13650,
+      "edhrec_rank": 13918,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.18"
       }
     },
     {
@@ -15577,10 +15589,10 @@
       "artist_ids": [
         "3605d81f-5c97-4958-9dcc-d44a85e10305"
       ],
-      "edhrec_rank": 12673,
+      "edhrec_rank": 13002,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.16"
       }
     },
     {
@@ -15622,10 +15634,10 @@
       "artist_ids": [
         "ebde5690-d401-46ba-8fd3-b9c07d5ef5a7"
       ],
-      "edhrec_rank": 2446,
+      "edhrec_rank": 2498,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.22"
       }
     },
     {
@@ -15666,10 +15678,10 @@
       "artist_ids": [
         "c8f27311-46a5-4eaf-9b2e-d660ed1db649"
       ],
-      "edhrec_rank": 918,
+      "edhrec_rank": 955,
       "properties": [],
       "prices": {
-        "usd": "4.56"
+        "usd": "4.47"
       }
     },
     {
@@ -15707,10 +15719,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 422,
+      "edhrec_rank": 429,
       "properties": [],
       "prices": {
-        "usd": "1.97"
+        "usd": "2.23"
       }
     },
     {
@@ -15752,10 +15764,10 @@
       "artist_ids": [
         "30fead7c-da53-4c1b-b514-4be6e5ce487c"
       ],
-      "edhrec_rank": 178,
+      "edhrec_rank": 179,
       "properties": [],
       "prices": {
-        "usd": "43.32"
+        "usd": "50.98"
       }
     },
     {
@@ -15796,10 +15808,10 @@
       "artist_ids": [
         "bd79c951-2552-45dd-aae7-a333c2b7c1ef"
       ],
-      "edhrec_rank": 3322,
+      "edhrec_rank": 3341,
       "properties": [],
       "prices": {
-        "usd": "10.73"
+        "usd": "13.14"
       }
     },
     {
@@ -15841,10 +15853,10 @@
       "artist_ids": [
         "44c3877f-8771-43dc-9e40-f4c765f59d2e"
       ],
-      "edhrec_rank": 2209,
+      "edhrec_rank": 2270,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.22"
       }
     },
     {
@@ -15887,10 +15899,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 20373,
+      "edhrec_rank": 20594,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.28"
       }
     },
     {
@@ -15929,10 +15941,10 @@
       "artist_ids": [
         "b4117364-73af-47e5-8cf0-901eeea09e01"
       ],
-      "edhrec_rank": 11488,
+      "edhrec_rank": 11652,
       "properties": [],
       "prices": {
-        "usd": "0.45"
+        "usd": "0.43"
       }
     },
     {
@@ -15970,10 +15982,10 @@
       "artist_ids": [
         "4441fe52-9e41-40c1-9b74-8510426279ab"
       ],
-      "edhrec_rank": 739,
+      "edhrec_rank": 772,
       "properties": [],
       "prices": {
-        "usd": "5.65"
+        "usd": "5.32"
       }
     },
     {
@@ -16011,10 +16023,10 @@
       "artist_ids": [
         "c4e0aa7c-a008-4d71-80ce-d5a1ca0b251b"
       ],
-      "edhrec_rank": 6783,
+      "edhrec_rank": 6885,
       "properties": [],
       "prices": {
-        "usd": "4.55"
+        "usd": "4.48"
       }
     },
     {
@@ -16056,10 +16068,10 @@
       "artist_ids": [
         "21e10012-06ae-44f2-b38d-3824dd2e73d4"
       ],
-      "edhrec_rank": 4991,
+      "edhrec_rank": 5001,
       "properties": [],
       "prices": {
-        "usd": "9.48"
+        "usd": "10.44"
       }
     },
     {
@@ -16116,7 +16128,7 @@
       "artist_ids": [
         "b5f1bd34-abee-40c9-99f7-a6ee089fb30b"
       ],
-      "edhrec_rank": 2703,
+      "edhrec_rank": 2750,
       "properties": [],
       "prices": {
         "usd": "0.33"
@@ -16155,10 +16167,10 @@
       "artist_ids": [
         "5a5ee217-9d28-419a-b92a-a2376c7d18b3"
       ],
-      "edhrec_rank": 2138,
+      "edhrec_rank": 2171,
       "properties": [],
       "prices": {
-        "usd": "23.41"
+        "usd": "22.26"
       }
     },
     {
@@ -16200,10 +16212,10 @@
       "artist_ids": [
         "e31f5891-08f7-4e5a-bac9-8b4570b8c1ab"
       ],
-      "edhrec_rank": 3676,
+      "edhrec_rank": 3834,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.37"
       }
     },
     {
@@ -16244,10 +16256,10 @@
       "artist_ids": [
         "3a243c17-3baa-4b53-9599-645311cd7d3d"
       ],
-      "edhrec_rank": 103,
+      "edhrec_rank": 99,
       "properties": [],
       "prices": {
-        "usd": "1.08"
+        "usd": "1.09"
       }
     },
     {
@@ -16316,10 +16328,10 @@
       "artist_ids": [
         "465e38b8-7eed-4d22-a6d2-d3603ee0c00b"
       ],
-      "edhrec_rank": 1168,
+      "edhrec_rank": 1180,
       "properties": [],
       "prices": {
-        "usd": "6.30"
+        "usd": "6.22"
       }
     },
     {
@@ -16392,10 +16404,10 @@
         "b376cbb6-e0d5-41e9-bbb2-9fbd40c71147",
         "a9065769-afcd-4e54-a3c0-5809e7b4108b"
       ],
-      "edhrec_rank": 3009,
+      "edhrec_rank": 2843,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.37"
       }
     },
     {
@@ -16434,10 +16446,10 @@
       "artist_ids": [
         "2e6a0611-9411-4ba4-98e3-c0e18cbf9f83"
       ],
-      "edhrec_rank": 6163,
+      "edhrec_rank": 6152,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.30"
       }
     },
     {
@@ -16479,10 +16491,10 @@
       "artist_ids": [
         "21ed6499-c4d3-4965-ab02-6c7228275bec"
       ],
-      "edhrec_rank": 4582,
+      "edhrec_rank": 4683,
       "properties": [],
       "prices": {
-        "usd": "3.97"
+        "usd": "4.14"
       }
     },
     {
@@ -16525,10 +16537,10 @@
       "artist_ids": [
         "c09ede88-a1b5-4a18-9895-dc8a965d28a5"
       ],
-      "edhrec_rank": 4845,
+      "edhrec_rank": 3886,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.34"
       }
     },
     {
@@ -16570,10 +16582,10 @@
       "artist_ids": [
         "b6476cc7-1576-47e8-9f6a-68d05b45cf62"
       ],
-      "edhrec_rank": 673,
+      "edhrec_rank": 634,
       "properties": [],
       "prices": {
-        "usd": "10.93"
+        "usd": "11.08"
       }
     },
     {
@@ -16629,10 +16641,10 @@
       "artist_ids": [
         "b0e80135-db5a-4b88-a0bc-815a0e94faa1"
       ],
-      "edhrec_rank": 16718,
+      "edhrec_rank": 17099,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.23"
       }
     },
     {
@@ -16671,10 +16683,10 @@
       "artist_ids": [
         "996ad764-4ae0-4952-8bb5-5a75c9d68275"
       ],
-      "edhrec_rank": 10800,
+      "edhrec_rank": 10145,
       "properties": [],
       "prices": {
-        "usd": "0.44"
+        "usd": "0.51"
       }
     },
     {
@@ -16716,10 +16728,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 61,
+      "edhrec_rank": 60,
       "properties": [],
       "prices": {
-        "usd": "15.49"
+        "usd": "15.98"
       }
     },
     {
@@ -16773,10 +16785,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 12740,
+      "edhrec_rank": 12988,
       "properties": [],
       "prices": {
-        "usd": "0.90"
+        "usd": "1.00"
       }
     },
     {
@@ -16818,10 +16830,10 @@
       "artist_ids": [
         "1629eaec-cc37-4870-bc89-1e8ca5569507"
       ],
-      "edhrec_rank": 6257,
+      "edhrec_rank": 5957,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.19"
       }
     },
     {
@@ -16865,10 +16877,10 @@
       "artist_ids": [
         "fc021f3d-773a-4706-bbe7-f602324f511f"
       ],
-      "edhrec_rank": 2028,
+      "edhrec_rank": 2095,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.33"
       }
     },
     {
@@ -16911,10 +16923,10 @@
       "artist_ids": [
         "0d8d6726-4051-445a-8374-a919aad98f38"
       ],
-      "edhrec_rank": 1457,
+      "edhrec_rank": 1501,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.25"
       }
     },
     {
@@ -16956,10 +16968,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 305,
+      "edhrec_rank": 315,
       "properties": [],
       "prices": {
-        "usd": "0.44"
+        "usd": "0.40"
       }
     },
     {
@@ -17001,10 +17013,10 @@
       "artist_ids": [
         "bec9ba7f-594e-4ff0-8172-9ec1fc909607"
       ],
-      "edhrec_rank": 2416,
+      "edhrec_rank": 2462,
       "properties": [],
       "prices": {
-        "usd": "0.98"
+        "usd": "1.25"
       }
     },
     {
@@ -17046,10 +17058,10 @@
       "artist_ids": [
         "c8b3ccf1-5c15-44f2-a7c5-1628c1a3f325"
       ],
-      "edhrec_rank": 6208,
+      "edhrec_rank": 5970,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.23"
       }
     },
     {
@@ -17091,10 +17103,10 @@
       "artist_ids": [
         "17948f16-611a-44b8-8d10-9895a0bdfff1"
       ],
-      "edhrec_rank": 5216,
+      "edhrec_rank": 4773,
       "properties": [],
       "prices": {
-        "usd": "6.04"
+        "usd": "6.94"
       }
     },
     {
@@ -17131,10 +17143,10 @@
       "artist_ids": [
         "e607a0d4-fc12-4c01-9e3f-501f5269b9cb"
       ],
-      "edhrec_rank": 7081,
+      "edhrec_rank": 7395,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.32"
       }
     },
     {
@@ -17168,10 +17180,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 4455,
+      "edhrec_rank": 4649,
       "properties": [],
       "prices": {
-        "usd": "0.72"
+        "usd": "0.68"
       }
     },
     {
@@ -17214,10 +17226,10 @@
       "artist_ids": [
         "f009de11-3c8d-4663-b996-ca0c3e997fad"
       ],
-      "edhrec_rank": 585,
+      "edhrec_rank": 584,
       "properties": [],
       "prices": {
-        "usd": "7.73"
+        "usd": "7.63"
       }
     },
     {
@@ -17258,7 +17270,7 @@
       "artist_ids": [
         "43cdce85-e4bc-424e-ac95-fd0886b66ff3"
       ],
-      "edhrec_rank": 2752,
+      "edhrec_rank": 2808,
       "properties": [],
       "prices": {
         "usd": "0.17"
@@ -17317,10 +17329,10 @@
       "artist_ids": [
         "fb7b61a8-13c5-4813-a749-9d3396801906"
       ],
-      "edhrec_rank": 7627,
+      "edhrec_rank": 7294,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.33"
       }
     },
     {
@@ -17360,10 +17372,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 409,
+      "edhrec_rank": 405,
       "properties": [],
       "prices": {
-        "usd": "3.47"
+        "usd": "2.83"
       }
     },
     {
@@ -17419,7 +17431,7 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 14597,
+      "edhrec_rank": 14903,
       "properties": [],
       "prices": {
         "usd": "0.14"
@@ -17450,9 +17462,12 @@
         "U",
         "W"
       ],
-      "edhrec_rank": 27850,
+      "edhrec_rank": 12633,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "0.52"
+      }
     },
     {
       "object": "card",
@@ -17494,10 +17509,10 @@
       "artist_ids": [
         "d281eab4-463a-4ba8-9039-8943737960a0"
       ],
-      "edhrec_rank": 1783,
+      "edhrec_rank": 1819,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.35"
       }
     },
     {
@@ -17535,10 +17550,10 @@
       "artist_ids": [
         "8df59511-f31c-461f-8a7d-0271aa1f973d"
       ],
-      "edhrec_rank": 17083,
+      "edhrec_rank": 17285,
       "properties": [],
       "prices": {
-        "usd": "5.79"
+        "usd": "5.68"
       }
     },
     {
@@ -17579,10 +17594,10 @@
       "artist_ids": [
         "d82b1138-76d3-49f7-9d8c-bc2e2d3e0b0a"
       ],
-      "edhrec_rank": 2250,
+      "edhrec_rank": 2064,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.28"
       }
     },
     {
@@ -17620,10 +17635,10 @@
       "artist_ids": [
         "c540d1fc-1500-457f-93cf-d6069ee66546"
       ],
-      "edhrec_rank": 5319,
+      "edhrec_rank": 5548,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.36"
       }
     },
     {
@@ -17666,10 +17681,10 @@
       "artist_ids": [
         "520618b3-95ee-4072-a648-f8a59d50effc"
       ],
-      "edhrec_rank": 3365,
+      "edhrec_rank": 3347,
       "properties": [],
       "prices": {
-        "usd": "16.28"
+        "usd": "16.01"
       }
     },
     {
@@ -17726,10 +17741,10 @@
       "artist_ids": [
         "b8266529-1ffe-41e7-9969-fcf39f61426b"
       ],
-      "edhrec_rank": 10661,
+      "edhrec_rank": 10917,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.31"
       }
     },
     {
@@ -17772,7 +17787,7 @@
       "artist_ids": [
         "a5048cc7-438a-4378-98e4-da99b78e1db0"
       ],
-      "edhrec_rank": 1950,
+      "edhrec_rank": 2026,
       "properties": [],
       "prices": {
         "usd": "0.20"
@@ -17817,10 +17832,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 399,
+      "edhrec_rank": 413,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.35"
       }
     },
     {
@@ -17862,7 +17877,7 @@
       "artist_ids": [
         "8f588167-5376-425b-ba13-ed207d9c1b39"
       ],
-      "edhrec_rank": 5801,
+      "edhrec_rank": 5502,
       "properties": [],
       "prices": {
         "usd": "0.25"
@@ -17902,10 +17917,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 1205,
+      "edhrec_rank": 1243,
       "properties": [],
       "prices": {
-        "usd": "1.99"
+        "usd": "1.43"
       }
     },
     {
@@ -17947,10 +17962,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 9089,
+      "edhrec_rank": 9247,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.32"
       }
     },
     {
@@ -18017,10 +18032,10 @@
       "artist_ids": [
         "bd8f7368-5b10-4554-b6b8-d052c6aca89f"
       ],
-      "edhrec_rank": 1964,
+      "edhrec_rank": 2000,
       "properties": [],
       "prices": {
-        "usd": "1.92"
+        "usd": "2.33"
       }
     },
     {
@@ -18059,10 +18074,10 @@
       "artist_ids": [
         "93bec3c0-0260-4d31-8064-5d01efb4153f"
       ],
-      "edhrec_rank": 1236,
+      "edhrec_rank": 1267,
       "properties": [],
       "prices": {
-        "usd": "0.48"
+        "usd": "0.67"
       }
     },
     {
@@ -18121,10 +18136,10 @@
       "artist_ids": [
         "0c066852-6fdb-42d0-aab9-db4038850da0"
       ],
-      "edhrec_rank": 14370,
+      "edhrec_rank": 14541,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.29"
       }
     },
     {
@@ -18167,7 +18182,7 @@
       "edhrec_rank": 419,
       "properties": [],
       "prices": {
-        "usd": "8.87"
+        "usd": "11.80"
       }
     },
     {
@@ -18209,10 +18224,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 6734,
+      "edhrec_rank": 5934,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.41"
       }
     },
     {
@@ -18251,10 +18266,10 @@
       "artist_ids": [
         "3593dd7e-c547-4a32-81cd-7da725f60118"
       ],
-      "edhrec_rank": 5179,
+      "edhrec_rank": 5328,
       "properties": [],
       "prices": {
-        "usd": "0.69"
+        "usd": "0.55"
       }
     },
     {
@@ -18320,10 +18335,10 @@
       "artist_ids": [
         "c4c9b5ea-4b31-40a0-8e40-d7dfeae43234"
       ],
-      "edhrec_rank": 5864,
+      "edhrec_rank": 6078,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.38"
       }
     },
     {
@@ -18360,10 +18375,10 @@
       "artist_ids": [
         "d48dd097-720d-476a-8722-6a02854ae28b"
       ],
-      "edhrec_rank": 2910,
+      "edhrec_rank": 2964,
       "properties": [],
       "prices": {
-        "usd": "17.02"
+        "usd": "20.06"
       }
     },
     {
@@ -18408,7 +18423,7 @@
       "edhrec_rank": 65,
       "properties": [],
       "prices": {
-        "usd": "21.35"
+        "usd": "21.40"
       }
     },
     {
@@ -18444,10 +18459,10 @@
       "artist_ids": [
         "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
       ],
-      "edhrec_rank": 19398,
+      "edhrec_rank": 19604,
       "properties": [],
       "prices": {
-        "usd": "2.99"
+        "usd": "3.03"
       }
     },
     {
@@ -18487,10 +18502,10 @@
       "artist_ids": [
         "c99a114b-c679-47df-a6e9-4f9d3ad5b114"
       ],
-      "edhrec_rank": 9220,
+      "edhrec_rank": 9376,
       "properties": [],
       "prices": {
-        "usd": "14.06"
+        "usd": "14.15"
       }
     },
     {
@@ -18561,10 +18576,10 @@
       "artist_ids": [
         "d82b1138-76d3-49f7-9d8c-bc2e2d3e0b0a"
       ],
-      "edhrec_rank": 3035,
+      "edhrec_rank": 3102,
       "properties": [],
       "prices": {
-        "usd": "1.73"
+        "usd": "1.93"
       }
     },
     {
@@ -18604,10 +18619,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 3844,
+      "edhrec_rank": 4025,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.24"
       }
     },
     {
@@ -18645,10 +18660,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 7128,
+      "edhrec_rank": 7255,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.22"
       }
     },
     {
@@ -18690,10 +18705,10 @@
       "artist_ids": [
         "91d65465-e8a6-4a4e-8b0e-0e07466cfa0f"
       ],
-      "edhrec_rank": 1201,
+      "edhrec_rank": 1206,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.29"
       }
     },
     {
@@ -18735,10 +18750,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 273,
+      "edhrec_rank": 276,
       "properties": [],
       "prices": {
-        "usd": "8.03"
+        "usd": "7.92"
       }
     },
     {
@@ -18780,10 +18795,10 @@
       "artist_ids": [
         "e956bacc-077d-4c12-b6bc-ba798b718af9"
       ],
-      "edhrec_rank": 1130,
+      "edhrec_rank": 1137,
       "properties": [],
       "prices": {
-        "usd": "1.59"
+        "usd": "1.82"
       }
     },
     {
@@ -18869,10 +18884,10 @@
       "artist_ids": [
         "e24bc1d0-446b-45e0-b215-89f581837aa4"
       ],
-      "edhrec_rank": 8482,
+      "edhrec_rank": 8691,
       "properties": [],
       "prices": {
-        "usd": "5.60"
+        "usd": "5.78"
       }
     },
     {
@@ -18911,10 +18926,10 @@
       "artist_ids": [
         "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
       ],
-      "edhrec_rank": 8764,
+      "edhrec_rank": 8620,
       "properties": [],
       "prices": {
-        "usd": "1.26"
+        "usd": "1.34"
       }
     },
     {
@@ -18974,10 +18989,10 @@
       "artist_ids": [
         "d084e74b-f63a-4107-b72c-ed6250ecc93b"
       ],
-      "edhrec_rank": 2875,
+      "edhrec_rank": 2947,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.39"
       }
     },
     {
@@ -19016,10 +19031,10 @@
       "artist_ids": [
         "d54c4a1a-c0c5-4834-84db-125d341f3ad8"
       ],
-      "edhrec_rank": 23463,
+      "edhrec_rank": 23621,
       "properties": [],
       "prices": {
-        "usd": "2.17"
+        "usd": "2.43"
       }
     },
     {
@@ -19062,10 +19077,10 @@
       "artist_ids": [
         "adad79bf-cd52-456a-b170-740ed8bff0fc"
       ],
-      "edhrec_rank": 539,
+      "edhrec_rank": 543,
       "properties": [],
       "prices": {
-        "usd": "11.17"
+        "usd": "12.97"
       }
     },
     {
@@ -19119,10 +19134,10 @@
       "artist_ids": [
         "bb2a9339-bbe4-445f-9736-3c43379ee076"
       ],
-      "edhrec_rank": 4733,
+      "edhrec_rank": 4830,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.40"
       }
     },
     {
@@ -19177,10 +19192,10 @@
       "artist_ids": [
         "35d39e75-5d6c-4318-9136-38cdfff34a05"
       ],
-      "edhrec_rank": 20405,
+      "edhrec_rank": 20696,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.20"
       }
     },
     {
@@ -19223,7 +19238,7 @@
       "artist_ids": [
         "b845b8ee-aeea-4822-bcf9-7230625ac95c"
       ],
-      "edhrec_rank": 26039,
+      "edhrec_rank": 26305,
       "properties": [],
       "prices": {
         "usd": "0.34"
@@ -19293,10 +19308,10 @@
       "artist_ids": [
         "f8e7f8d6-6dde-4059-973c-30f1fd1bbe4e"
       ],
-      "edhrec_rank": 1129,
+      "edhrec_rank": 1152,
       "properties": [],
       "prices": {
-        "usd": "4.84"
+        "usd": "5.11"
       }
     },
     {
@@ -19335,10 +19350,10 @@
       "artist_ids": [
         "89c0f62c-0647-4f8d-b650-8242f8fea36a"
       ],
-      "edhrec_rank": 6777,
+      "edhrec_rank": 6589,
       "properties": [],
       "prices": {
-        "usd": "3.26"
+        "usd": "3.29"
       }
     },
     {
@@ -19379,10 +19394,10 @@
       "artist_ids": [
         "fb7b61a8-13c5-4813-a749-9d3396801906"
       ],
-      "edhrec_rank": 4517,
+      "edhrec_rank": 4725,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.16"
       }
     },
     {
@@ -19423,10 +19438,10 @@
       "artist_ids": [
         "fb7b61a8-13c5-4813-a749-9d3396801906"
       ],
-      "edhrec_rank": 4860,
+      "edhrec_rank": 5091,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.25"
       }
     },
     {
@@ -19470,10 +19485,10 @@
       "artist_ids": [
         "22211c1d-e15e-4db3-9350-e4a9862928bb"
       ],
-      "edhrec_rank": 2405,
+      "edhrec_rank": 2323,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.25"
       }
     },
     {
@@ -19500,11 +19515,11 @@
         "U",
         "W"
       ],
-      "edhrec_rank": 7197,
+      "edhrec_rank": 5086,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "2.18"
+        "usd": "3.01"
       }
     },
     {
@@ -19543,10 +19558,10 @@
       "rarity": "common",
       "artist": "Svetlin Velinov",
       "artist_ids": [],
-      "edhrec_rank": 5091,
+      "edhrec_rank": 5306,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.22"
       }
     },
     {
@@ -19587,10 +19602,10 @@
       "artist_ids": [
         "d072adde-7194-4bf0-b9ca-b42d8973b0ff"
       ],
-      "edhrec_rank": 3097,
+      "edhrec_rank": 3253,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.16"
       }
     },
     {
@@ -19631,10 +19646,10 @@
       "artist_ids": [
         "fa8fd324-099a-43f2-9c57-97f64e38a5e9"
       ],
-      "edhrec_rank": 3579,
+      "edhrec_rank": 3663,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.23"
       }
     },
     {
@@ -19672,10 +19687,10 @@
       "artist_ids": [
         "17948f16-611a-44b8-8d10-9895a0bdfff1"
       ],
-      "edhrec_rank": 506,
+      "edhrec_rank": 467,
       "properties": [],
       "prices": {
-        "usd": "7.21"
+        "usd": "8.38"
       }
     },
     {
@@ -19717,10 +19732,10 @@
       "artist_ids": [
         "bb677b1a-ce51-4888-83d6-5a94de461ff9"
       ],
-      "edhrec_rank": 2954,
+      "edhrec_rank": 3135,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.31"
       }
     },
     {
@@ -19762,10 +19777,10 @@
       "artist_ids": [
         "f28c54ff-bbe3-485d-81a4-b2cb49430a52"
       ],
-      "edhrec_rank": 5982,
+      "edhrec_rank": 6110,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.11"
       }
     },
     {
@@ -19807,7 +19822,7 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 16097,
+      "edhrec_rank": 16398,
       "properties": [],
       "prices": {
         "usd": "0.32"
@@ -19852,10 +19867,10 @@
       "artist_ids": [
         "0fad2c48-a56e-4a0b-b512-224f6f238f20"
       ],
-      "edhrec_rank": 105,
+      "edhrec_rank": 100,
       "properties": [],
       "prices": {
-        "usd": "0.98"
+        "usd": "0.88"
       }
     },
     {
@@ -19896,10 +19911,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 6658,
+      "edhrec_rank": 6720,
       "properties": [],
       "prices": {
-        "usd": "0.64"
+        "usd": "0.85"
       }
     },
     {
@@ -19938,10 +19953,10 @@
       "artist_ids": [
         "3593dd7e-c547-4a32-81cd-7da725f60118"
       ],
-      "edhrec_rank": 7454,
+      "edhrec_rank": 7604,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.40"
       }
     },
     {
@@ -19984,10 +19999,10 @@
       "artist_ids": [
         "aa7e89ed-d294-4633-9057-ce04dacfcfa4"
       ],
-      "edhrec_rank": 2952,
+      "edhrec_rank": 2990,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.26"
       }
     },
     {
@@ -20026,10 +20041,10 @@
       "artist_ids": [
         "3130411f-ddd5-4cab-a2f4-0a9c3b95a26e"
       ],
-      "edhrec_rank": 18219,
+      "edhrec_rank": 18423,
       "properties": [],
       "prices": {
-        "usd": "1.08"
+        "usd": "1.14"
       }
     },
     {
@@ -20067,10 +20082,10 @@
       "artist_ids": [
         "bba69285-2445-4a4b-a847-59397be972ea"
       ],
-      "edhrec_rank": 1139,
+      "edhrec_rank": 1170,
       "properties": [],
       "prices": {
-        "usd": "14.33"
+        "usd": "15.80"
       }
     },
     {
@@ -20112,10 +20127,10 @@
       "artist_ids": [
         "96a53b95-fe5f-4fbb-9411-ccf4ee150aca"
       ],
-      "edhrec_rank": 1629,
+      "edhrec_rank": 1662,
       "properties": [],
       "prices": {
-        "usd": "6.04"
+        "usd": "6.53"
       }
     },
     {
@@ -20156,10 +20171,10 @@
       "artist_ids": [
         "7f1868e3-325f-4df9-8f27-a381fed4f0fc"
       ],
-      "edhrec_rank": 1499,
+      "edhrec_rank": 1458,
       "properties": [],
       "prices": {
-        "usd": "6.41"
+        "usd": "6.63"
       }
     },
     {
@@ -20197,10 +20212,10 @@
       "artist_ids": [
         "8fa1fdf0-96d6-46f4-a7ff-b1c0257c3735"
       ],
-      "edhrec_rank": 8981,
+      "edhrec_rank": 9344,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.23"
       }
     },
     {
@@ -20272,10 +20287,10 @@
       "artist_ids": [
         "0fbd4798-76eb-46d5-a5d4-1e3a25870e34"
       ],
-      "edhrec_rank": 9852,
+      "edhrec_rank": 10102,
       "properties": [],
       "prices": {
-        "usd": "0.45"
+        "usd": "0.53"
       }
     },
     {
@@ -20316,7 +20331,7 @@
       "artist_ids": [
         "9fa4339d-f3d4-4def-8115-166845f07048"
       ],
-      "edhrec_rank": 20213,
+      "edhrec_rank": 20537,
       "properties": [],
       "prices": {
         "usd": "0.59"
@@ -20361,10 +20376,10 @@
       "artist_ids": [
         "a662cb71-4770-4b49-8b03-2cf8497049a7"
       ],
-      "edhrec_rank": 796,
+      "edhrec_rank": 760,
       "properties": [],
       "prices": {
-        "usd": "6.14"
+        "usd": "7.61"
       }
     },
     {
@@ -20435,10 +20450,10 @@
       "artist_ids": [
         "c7c15d49-f84b-4d98-9a34-e80e8347b756"
       ],
-      "edhrec_rank": 660,
+      "edhrec_rank": 621,
       "properties": [],
       "prices": {
-        "usd": "0.89"
+        "usd": "0.80"
       }
     },
     {
@@ -20477,10 +20492,10 @@
       "artist_ids": [
         "3130411f-ddd5-4cab-a2f4-0a9c3b95a26e"
       ],
-      "edhrec_rank": 19343,
+      "edhrec_rank": 19520,
       "properties": [],
       "prices": {
-        "usd": "0.74"
+        "usd": "0.72"
       }
     },
     {
@@ -20514,10 +20529,10 @@
       "artist_ids": [
         "14a1de4b-1237-4e7b-8868-b71e87c9a46e"
       ],
-      "edhrec_rank": 15926,
+      "edhrec_rank": 16110,
       "properties": [],
       "prices": {
-        "usd": "0.50"
+        "usd": "0.52"
       }
     },
     {
@@ -20559,10 +20574,10 @@
       "artist_ids": [
         "3593dd7e-c547-4a32-81cd-7da725f60118"
       ],
-      "edhrec_rank": 3818,
+      "edhrec_rank": 3975,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.45"
       }
     },
     {
@@ -20604,10 +20619,10 @@
       "artist_ids": [
         "adb9ad6d-6173-454b-8b50-a102b182548b"
       ],
-      "edhrec_rank": 2240,
+      "edhrec_rank": 2251,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.26"
       }
     },
     {
@@ -20647,10 +20662,10 @@
       "artist_ids": [
         "6dd06426-59fe-4b9c-aad5-6da8446a5c3d"
       ],
-      "edhrec_rank": 4169,
+      "edhrec_rank": 4223,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.29"
       }
     },
     {
@@ -20690,10 +20705,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 4837,
+      "edhrec_rank": 4701,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.33"
       }
     },
     {
@@ -20720,11 +20735,11 @@
         "B",
         "G"
       ],
-      "edhrec_rank": 18459,
+      "edhrec_rank": 13761,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.14"
       }
     },
     {
@@ -20764,10 +20779,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 16275,
+      "edhrec_rank": 16556,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.17"
       }
     },
     {
@@ -20813,10 +20828,10 @@
       "artist_ids": [
         "81995d11-da98-4f8b-89bd-b88ca2ddb06b"
       ],
-      "edhrec_rank": 452,
+      "edhrec_rank": 462,
       "properties": [],
       "prices": {
-        "usd": "21.32"
+        "usd": "20.09"
       }
     },
     {
@@ -20870,10 +20885,10 @@
       "artist_ids": [
         "269392ac-4c06-4650-98e2-d49a5a7f2371"
       ],
-      "edhrec_rank": 2029,
+      "edhrec_rank": 2017,
       "properties": [],
       "prices": {
-        "usd": "11.64"
+        "usd": "12.44"
       }
     },
     {
@@ -20915,10 +20930,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 5901,
+      "edhrec_rank": 5617,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.23"
       }
     },
     {
@@ -20960,10 +20975,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 1478,
+      "edhrec_rank": 1465,
       "properties": [],
       "prices": {
-        "usd": "1.23"
+        "usd": "1.53"
       }
     },
     {
@@ -21005,10 +21020,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 4231,
+      "edhrec_rank": 4316,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.15"
       }
     },
     {
@@ -21046,10 +21061,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 281,
+      "edhrec_rank": 280,
       "properties": [],
       "prices": {
-        "usd": "13.63"
+        "usd": "14.24"
       }
     },
     {
@@ -21091,10 +21106,10 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 9200,
+      "edhrec_rank": 9255,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.26"
       }
     },
     {
@@ -21137,10 +21152,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 783,
+      "edhrec_rank": 804,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.28"
       }
     },
     {
@@ -21183,7 +21198,7 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 22741,
+      "edhrec_rank": 22958,
       "properties": [],
       "prices": {
         "usd": "0.20"
@@ -21246,10 +21261,10 @@
       "artist_ids": [
         "e20f06f2-4bcc-4dee-9b21-0f80a57e4c49"
       ],
-      "edhrec_rank": 1755,
+      "edhrec_rank": 1638,
       "properties": [],
       "prices": {
-        "usd": "0.94"
+        "usd": "2.66"
       }
     },
     {
@@ -21284,7 +21299,7 @@
       "artist_ids": [
         "a9ddb513-51c7-455c-ab8f-5b90aae9f75b"
       ],
-      "edhrec_rank": 21936,
+      "edhrec_rank": 21998,
       "properties": [],
       "prices": {
         "usd": "235.12"
@@ -21329,10 +21344,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 97,
+      "edhrec_rank": 93,
       "properties": [],
       "prices": {
-        "usd": "1.11"
+        "usd": "1.23"
       }
     },
     {
@@ -21371,10 +21386,10 @@
       "artist_ids": [
         "85908891-3cc7-42b0-9b54-27ed0fe89c53"
       ],
-      "edhrec_rank": 10193,
+      "edhrec_rank": 10308,
       "properties": [],
       "prices": {
-        "usd": "0.89"
+        "usd": "1.05"
       }
     },
     {
@@ -21416,10 +21431,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 376,
+      "edhrec_rank": 393,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.34"
       }
     },
     {
@@ -21462,10 +21477,10 @@
       "artist_ids": [
         "81995d11-da98-4f8b-89bd-b88ca2ddb06b"
       ],
-      "edhrec_rank": 1615,
+      "edhrec_rank": 1669,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.07"
       }
     },
     {
@@ -21507,10 +21522,10 @@
       "artist_ids": [
         "608e3b85-cdd3-4d1a-8a3a-7f1ed8856f6b"
       ],
-      "edhrec_rank": 3240,
+      "edhrec_rank": 3386,
       "properties": [],
       "prices": {
-        "usd": "0.43"
+        "usd": "0.40"
       }
     },
     {
@@ -21538,11 +21553,11 @@
         "U",
         "W"
       ],
-      "edhrec_rank": 5247,
+      "edhrec_rank": 4877,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.43"
+        "usd": "0.79"
       }
     },
     {
@@ -21589,10 +21604,10 @@
       "artist_ids": [
         "a662cb71-4770-4b49-8b03-2cf8497049a7"
       ],
-      "edhrec_rank": 345,
+      "edhrec_rank": 355,
       "properties": [],
       "prices": {
-        "usd": "17.95"
+        "usd": "17.65"
       }
     },
     {
@@ -21654,7 +21669,7 @@
       "artist_ids": [
         "39cb50cf-0223-43c7-bd96-afb5f05c7e43"
       ],
-      "edhrec_rank": 2652,
+      "edhrec_rank": 2471,
       "properties": [],
       "prices": {
         "usd": "1.59"
@@ -21695,10 +21710,10 @@
       "artist_ids": [
         "92f6c2c1-fa57-4b52-99c4-0fd866c13dc9"
       ],
-      "edhrec_rank": 4696,
+      "edhrec_rank": 4846,
       "properties": [],
       "prices": {
-        "usd": "0.57"
+        "usd": "0.56"
       }
     },
     {
@@ -21738,10 +21753,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 5693,
+      "edhrec_rank": 5804,
       "properties": [],
       "prices": {
-        "usd": "0.56"
+        "usd": "0.60"
       }
     },
     {
@@ -21782,10 +21797,10 @@
       "artist_ids": [
         "0d8d6726-4051-445a-8374-a919aad98f38"
       ],
-      "edhrec_rank": 761,
+      "edhrec_rank": 742,
       "properties": [],
       "prices": {
-        "usd": "0.11"
+        "usd": "0.15"
       }
     },
     {
@@ -21829,10 +21844,10 @@
       "artist_ids": [
         "afc47cec-3ccc-404e-a8c6-4d83dd504271"
       ],
-      "edhrec_rank": 293,
+      "edhrec_rank": 302,
       "properties": [],
       "prices": {
-        "usd": "0.49"
+        "usd": "0.47"
       }
     },
     {
@@ -21888,7 +21903,7 @@
       "artist_ids": [
         "af6862b1-2e08-445f-b709-37ef4c00c4db"
       ],
-      "edhrec_rank": 9174,
+      "edhrec_rank": 9475,
       "properties": [],
       "prices": {
         "usd": "0.25"
@@ -21932,10 +21947,10 @@
       "artist_ids": [
         "90edbd2e-9462-4394-b0b4-02885b4e56b3"
       ],
-      "edhrec_rank": 4174,
+      "edhrec_rank": 4327,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.22"
       }
     },
     {
@@ -22002,10 +22017,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 2686,
+      "edhrec_rank": 2699,
       "properties": [],
       "prices": {
-        "usd": "0.46"
+        "usd": "0.39"
       }
     },
     {
@@ -22044,10 +22059,10 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 5029,
+      "edhrec_rank": 5053,
       "properties": [],
       "prices": {
-        "usd": "0.45"
+        "usd": "0.46"
       }
     },
     {
@@ -22114,10 +22129,10 @@
       "artist_ids": [
         "d20672ca-0555-4238-a984-fd171d36b247"
       ],
-      "edhrec_rank": 2573,
+      "edhrec_rank": 2593,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.30"
       }
     },
     {
@@ -22157,10 +22172,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 197,
+      "edhrec_rank": 201,
       "properties": [],
       "prices": {
-        "usd": "3.27"
+        "usd": "2.74"
       }
     },
     {
@@ -22200,10 +22215,10 @@
       "artist_ids": [
         "eff6a2bb-7ca1-432e-8af9-aa85ee2359a2"
       ],
-      "edhrec_rank": 5346,
+      "edhrec_rank": 5411,
       "properties": [],
       "prices": {
-        "usd": "1.60"
+        "usd": "1.53"
       }
     },
     {
@@ -22245,10 +22260,10 @@
       "artist_ids": [
         "3de0bcf5-44b7-4c1e-9040-04c5396e79b0"
       ],
-      "edhrec_rank": 226,
+      "edhrec_rank": 221,
       "properties": [],
       "prices": {
-        "usd": "28.79"
+        "usd": "31.34"
       }
     },
     {
@@ -22288,10 +22303,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 7379,
+      "edhrec_rank": 7053,
       "properties": [],
       "prices": {
-        "usd": "0.87"
+        "usd": "1.30"
       }
     },
     {
@@ -22362,10 +22377,10 @@
       "artist_ids": [
         "b5f49d0d-8056-48e3-b614-090e656b4f9c"
       ],
-      "edhrec_rank": 8832,
+      "edhrec_rank": 8903,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.32"
       }
     },
     {
@@ -22406,10 +22421,10 @@
       "artist_ids": [
         "3a243c17-3baa-4b53-9599-645311cd7d3d"
       ],
-      "edhrec_rank": 5562,
+      "edhrec_rank": 5727,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.22"
       }
     },
     {
@@ -22476,10 +22491,10 @@
       "artist_ids": [
         "0fad2c48-a56e-4a0b-b512-224f6f238f20"
       ],
-      "edhrec_rank": 1592,
+      "edhrec_rank": 1612,
       "properties": [],
       "prices": {
-        "usd": "0.49"
+        "usd": "0.52"
       }
     },
     {
@@ -22520,10 +22535,10 @@
       "artist_ids": [
         "43cdce85-e4bc-424e-ac95-fd0886b66ff3"
       ],
-      "edhrec_rank": 16717,
+      "edhrec_rank": 17048,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.34"
       }
     },
     {
@@ -22562,10 +22577,10 @@
       "artist_ids": [
         "3a243c17-3baa-4b53-9599-645311cd7d3d"
       ],
-      "edhrec_rank": 18873,
+      "edhrec_rank": 19268,
       "properties": [],
       "prices": {
-        "usd": "0.97"
+        "usd": "1.00"
       }
     },
     {
@@ -22606,10 +22621,10 @@
       "artist_ids": [
         "0d8d6726-4051-445a-8374-a919aad98f38"
       ],
-      "edhrec_rank": 374,
+      "edhrec_rank": 384,
       "properties": [],
       "prices": {
-        "usd": "0.47"
+        "usd": "0.62"
       }
     },
     {
@@ -22655,10 +22670,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 347,
+      "edhrec_rank": 356,
       "properties": [],
       "prices": {
-        "usd": "17.73"
+        "usd": "18.15"
       }
     },
     {
@@ -22727,10 +22742,10 @@
       "artist_ids": [
         "b5f49d0d-8056-48e3-b614-090e656b4f9c"
       ],
-      "edhrec_rank": 1712,
+      "edhrec_rank": 1743,
       "properties": [],
       "prices": {
-        "usd": "0.43"
+        "usd": "0.48"
       }
     },
     {
@@ -22785,10 +22800,10 @@
       "artist_ids": [
         "89cc9475-dda2-4d13-bf88-54b92867a25c"
       ],
-      "edhrec_rank": 3162,
+      "edhrec_rank": 3062,
       "properties": [],
       "prices": {
-        "usd": "1.25"
+        "usd": "2.00"
       }
     },
     {
@@ -22844,10 +22859,10 @@
       "artist_ids": [
         "d48dd097-720d-476a-8722-6a02854ae28b"
       ],
-      "edhrec_rank": 1593,
+      "edhrec_rank": 1620,
       "properties": [],
       "prices": {
-        "usd": "0.59"
+        "usd": "0.60"
       }
     },
     {
@@ -22889,10 +22904,10 @@
       "artist_ids": [
         "91d65465-e8a6-4a4e-8b0e-0e07466cfa0f"
       ],
-      "edhrec_rank": 5356,
+      "edhrec_rank": 5156,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.30"
       }
     },
     {
@@ -22951,7 +22966,7 @@
       "artist_ids": [
         "0c066852-6fdb-42d0-aab9-db4038850da0"
       ],
-      "edhrec_rank": 12279,
+      "edhrec_rank": 12439,
       "properties": [],
       "prices": {
         "usd": "0.40"
@@ -23009,10 +23024,10 @@
       "artist_ids": [
         "14a1de4b-1237-4e7b-8868-b71e87c9a46e"
       ],
-      "edhrec_rank": 14241,
+      "edhrec_rank": 14512,
       "properties": [],
       "prices": {
-        "usd": "16.94"
+        "usd": "12.99"
       }
     },
     {
@@ -23051,10 +23066,10 @@
       "artist_ids": [
         "262c8e55-4efc-467b-a042-6f734b9d2e01"
       ],
-      "edhrec_rank": 3700,
+      "edhrec_rank": 3719,
       "properties": [],
       "prices": {
-        "usd": "17.65"
+        "usd": "18.95"
       }
     },
     {
@@ -23099,10 +23114,10 @@
       "artist_ids": [
         "3130411f-ddd5-4cab-a2f4-0a9c3b95a26e"
       ],
-      "edhrec_rank": 27315,
+      "edhrec_rank": 27464,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.20"
       }
     },
     {
@@ -23139,10 +23154,10 @@
       "artist_ids": [
         "1952c90b-a5a7-4328-9f7c-e11064f59daf"
       ],
-      "edhrec_rank": 808,
+      "edhrec_rank": 880,
       "properties": [],
       "prices": {
-        "usd": "0.47"
+        "usd": "0.51"
       }
     },
     {
@@ -23169,11 +23184,11 @@
         "G",
         "W"
       ],
-      "edhrec_rank": 8408,
+      "edhrec_rank": 7845,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.25"
       }
     },
     {
@@ -23227,10 +23242,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 4254,
+      "edhrec_rank": 4364,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.34"
       }
     },
     {
@@ -23269,10 +23284,10 @@
       "artist_ids": [
         "3593dd7e-c547-4a32-81cd-7da725f60118"
       ],
-      "edhrec_rank": 2308,
+      "edhrec_rank": 2347,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.36"
       }
     },
     {
@@ -23311,10 +23326,10 @@
       "artist_ids": [
         "d54c4a1a-c0c5-4834-84db-125d341f3ad8"
       ],
-      "edhrec_rank": 5452,
+      "edhrec_rank": 5459,
       "properties": [],
       "prices": {
-        "usd": "105.72"
+        "usd": "124.65"
       }
     },
     {
@@ -23356,10 +23371,10 @@
       "artist_ids": [
         "70b1ba71-4ee1-4087-8a9e-ea919f20ebff"
       ],
-      "edhrec_rank": 10127,
+      "edhrec_rank": 10007,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.13"
       }
     },
     {
@@ -23400,10 +23415,10 @@
       "artist_ids": [
         "8a56d854-b424-45ec-9262-e993a382a961"
       ],
-      "edhrec_rank": 27316,
+      "edhrec_rank": 27667,
       "properties": [],
       "prices": {
-        "usd": "0.98"
+        "usd": "1.01"
       }
     },
     {
@@ -23445,10 +23460,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 21966,
+      "edhrec_rank": 22284,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.20"
       }
     },
     {
@@ -23489,10 +23504,10 @@
       "artist_ids": [
         "c99a114b-c679-47df-a6e9-4f9d3ad5b114"
       ],
-      "edhrec_rank": 27175,
+      "edhrec_rank": 27406,
       "properties": [],
       "prices": {
-        "usd": "1.06"
+        "usd": "1.01"
       }
     },
     {
@@ -23533,10 +23548,10 @@
       "artist_ids": [
         "41084244-a313-4d14-8123-db05855f9cfe"
       ],
-      "edhrec_rank": 7295,
+      "edhrec_rank": 7446,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.38"
       }
     },
     {
@@ -23594,10 +23609,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 1974,
+      "edhrec_rank": 1915,
       "properties": [],
       "prices": {
-        "usd": "5.19"
+        "usd": "7.45"
       }
     },
     {
@@ -23636,10 +23651,10 @@
       "artist_ids": [
         "21ed6499-c4d3-4965-ab02-6c7228275bec"
       ],
-      "edhrec_rank": 2509,
+      "edhrec_rank": 2503,
       "properties": [],
       "prices": {
-        "usd": "1.21"
+        "usd": "1.29"
       }
     },
     {
@@ -23709,10 +23724,10 @@
       "artist_ids": [
         "6190569f-5e77-4bc1-bf22-9f85dba3a139"
       ],
-      "edhrec_rank": 1238,
+      "edhrec_rank": 1211,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.42"
       }
     },
     {
@@ -23771,10 +23786,10 @@
       "artist_ids": [
         "0c066852-6fdb-42d0-aab9-db4038850da0"
       ],
-      "edhrec_rank": 13078,
+      "edhrec_rank": 13301,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.38"
       }
     },
     {
@@ -23816,10 +23831,10 @@
       "artist_ids": [
         "85908891-3cc7-42b0-9b54-27ed0fe89c53"
       ],
-      "edhrec_rank": 3766,
+      "edhrec_rank": 3680,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.32"
       }
     },
     {
@@ -23895,10 +23910,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 1765,
+      "edhrec_rank": 1598,
       "properties": [],
       "prices": {
-        "usd": "2.23"
+        "usd": "2.45"
       }
     },
     {
@@ -23954,10 +23969,10 @@
       "artist_ids": [
         "2c14303e-97a3-45fa-9bd8-59e5332a65f9"
       ],
-      "edhrec_rank": 6594,
+      "edhrec_rank": 6798,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.25"
       }
     },
     {
@@ -23998,10 +24013,10 @@
       "artist_ids": [
         "43cdce85-e4bc-424e-ac95-fd0886b66ff3"
       ],
-      "edhrec_rank": 2176,
+      "edhrec_rank": 2249,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.44"
       }
     },
     {
@@ -24043,10 +24058,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 149,
+      "edhrec_rank": 137,
       "properties": [],
       "prices": {
-        "usd": "33.82"
+        "usd": "33.40"
       }
     },
     {
@@ -24088,10 +24103,10 @@
       "artist_ids": [
         "74246024-92b4-43d0-a5af-a3f9f2a35d5f"
       ],
-      "edhrec_rank": 6266,
+      "edhrec_rank": 6449,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.25"
       }
     },
     {
@@ -24132,10 +24147,10 @@
       "artist_ids": [
         "4441fe52-9e41-40c1-9b74-8510426279ab"
       ],
-      "edhrec_rank": 1100,
+      "edhrec_rank": 1127,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.32"
       }
     },
     {
@@ -24174,10 +24189,10 @@
       "artist_ids": [
         "f28c54ff-bbe3-485d-81a4-b2cb49430a52"
       ],
-      "edhrec_rank": 11816,
+      "edhrec_rank": 11897,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.07"
       }
     },
     {
@@ -24222,10 +24237,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 8021,
+      "edhrec_rank": 7391,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.16"
       }
     },
     {
@@ -24268,10 +24283,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 981,
+      "edhrec_rank": 928,
       "properties": [],
       "prices": {
-        "usd": "8.23"
+        "usd": "4.33"
       }
     },
     {
@@ -24313,10 +24328,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 6943,
+      "edhrec_rank": 6911,
       "properties": [],
       "prices": {
-        "usd": "38.79"
+        "usd": "40.49"
       }
     },
     {
@@ -24375,10 +24390,10 @@
       "artist_ids": [
         "0c066852-6fdb-42d0-aab9-db4038850da0"
       ],
-      "edhrec_rank": 15911,
+      "edhrec_rank": 16049,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.24"
       }
     },
     {
@@ -24419,10 +24434,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 4275,
+      "edhrec_rank": 4380,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.23"
       }
     },
     {
@@ -24462,10 +24477,10 @@
       "artist_ids": [
         "bb677b1a-ce51-4888-83d6-5a94de461ff9"
       ],
-      "edhrec_rank": 4721,
+      "edhrec_rank": 4648,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.26"
       }
     },
     {
@@ -24507,10 +24522,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 4306,
+      "edhrec_rank": 4441,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.17"
       }
     },
     {
@@ -24553,10 +24568,10 @@
       "artist_ids": [
         "bec9ba7f-594e-4ff0-8172-9ec1fc909607"
       ],
-      "edhrec_rank": 698,
+      "edhrec_rank": 709,
       "properties": [],
       "prices": {
-        "usd": "5.77"
+        "usd": "5.83"
       }
     },
     {
@@ -24598,10 +24613,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 161,
+      "edhrec_rank": 163,
       "properties": [],
       "prices": {
-        "usd": "30.48"
+        "usd": "31.91"
       }
     },
     {
@@ -24640,7 +24655,7 @@
       "artist_ids": [
         "9c77c81a-3b3f-4e94-a834-327d01cd6b35"
       ],
-      "edhrec_rank": 13703,
+      "edhrec_rank": 13909,
       "properties": [],
       "prices": {
         "usd": "0.49"
@@ -24685,10 +24700,10 @@
       "artist_ids": [
         "f0c43e1b-1853-4abc-8a1b-d7dda6c1d592"
       ],
-      "edhrec_rank": 2363,
+      "edhrec_rank": 2224,
       "properties": [],
       "prices": {
-        "usd": "1.62"
+        "usd": "2.34"
       }
     },
     {
@@ -24724,10 +24739,10 @@
       "artist_ids": [
         "2c14303e-97a3-45fa-9bd8-59e5332a65f9"
       ],
-      "edhrec_rank": 1207,
+      "edhrec_rank": 1235,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.35"
       }
     },
     {
@@ -24764,10 +24779,10 @@
       "artist_ids": [
         "269392ac-4c06-4650-98e2-d49a5a7f2371"
       ],
-      "edhrec_rank": 4019,
+      "edhrec_rank": 4168,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.27"
       }
     },
     {
@@ -24806,10 +24821,10 @@
       "artist_ids": [
         "37970e22-9cee-44c1-af44-5ee27cf26b76"
       ],
-      "edhrec_rank": 13350,
+      "edhrec_rank": 13459,
       "properties": [],
       "prices": {
-        "usd": "1.16"
+        "usd": "1.10"
       }
     },
     {
@@ -24876,10 +24891,10 @@
       "artist_ids": [
         "bba69285-2445-4a4b-a847-59397be972ea"
       ],
-      "edhrec_rank": 8497,
+      "edhrec_rank": 8442,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.25"
       }
     },
     {
@@ -24946,10 +24961,10 @@
       "artist_ids": [
         "266ab861-ed64-4ba5-865c-f18758421cc3"
       ],
-      "edhrec_rank": 253,
+      "edhrec_rank": 249,
       "properties": [],
       "prices": {
-        "usd": "13.28"
+        "usd": "13.22"
       }
     },
     {
@@ -24991,10 +25006,10 @@
       "artist_ids": [
         "7b1b0ce9-2c58-4321-a2a7-cdc94feae082"
       ],
-      "edhrec_rank": 118,
+      "edhrec_rank": 120,
       "properties": [],
       "prices": {
-        "usd": "30.65"
+        "usd": "33.52"
       }
     },
     {
@@ -25038,10 +25053,10 @@
       "artist_ids": [
         "d084e74b-f63a-4107-b72c-ed6250ecc93b"
       ],
-      "edhrec_rank": 2166,
+      "edhrec_rank": 2255,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.51"
       }
     },
     {
@@ -25094,10 +25109,10 @@
       "artist_ids": [
         "85908891-3cc7-42b0-9b54-27ed0fe89c53"
       ],
-      "edhrec_rank": 5078,
+      "edhrec_rank": 5213,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.33"
       }
     },
     {
@@ -25131,10 +25146,10 @@
       "artist_ids": [
         "2c3d2473-ff5d-4309-8194-e0b2def2ab65"
       ],
-      "edhrec_rank": 51,
+      "edhrec_rank": 50,
       "properties": [],
       "prices": {
-        "usd": "29.17"
+        "usd": "32.13"
       }
     },
     {
@@ -25168,10 +25183,10 @@
       "artist_ids": [
         "634430a7-b5c3-4e4a-b2ac-164e084e47c9"
       ],
-      "edhrec_rank": 517,
+      "edhrec_rank": 524,
       "properties": [],
       "prices": {
-        "usd": "26.28"
+        "usd": "29.49"
       }
     },
     {
@@ -25208,10 +25223,10 @@
       "artist_ids": [
         "38433e15-f0f5-4223-a985-2d13c4aa0922"
       ],
-      "edhrec_rank": 23707,
+      "edhrec_rank": 23921,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.23"
       }
     },
     {
@@ -25248,10 +25263,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 2702,
+      "edhrec_rank": 2752,
       "properties": [],
       "prices": {
-        "usd": "1.52"
+        "usd": "1.55"
       }
     },
     {
@@ -25293,10 +25308,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 7287,
+      "edhrec_rank": 7438,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.12"
       }
     },
     {
@@ -25338,10 +25353,10 @@
       "artist_ids": [
         "7f1868e3-325f-4df9-8f27-a381fed4f0fc"
       ],
-      "edhrec_rank": 3211,
+      "edhrec_rank": 3262,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.39"
       }
     },
     {
@@ -25368,11 +25383,11 @@
         "G",
         "U"
       ],
-      "edhrec_rank": 8992,
+      "edhrec_rank": 8344,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.23"
       }
     },
     {
@@ -25411,10 +25426,10 @@
       "artist_ids": [
         "4b149402-618d-4f54-9db8-788e4a5bce70"
       ],
-      "edhrec_rank": 2900,
+      "edhrec_rank": 2889,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.26"
       }
     },
     {
@@ -25453,10 +25468,10 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 8934,
+      "edhrec_rank": 9164,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.20"
       }
     },
     {
@@ -25511,10 +25526,10 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 6455,
+      "edhrec_rank": 6637,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.20"
       }
     },
     {
@@ -25553,7 +25568,7 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 12254,
+      "edhrec_rank": 12465,
       "properties": [],
       "prices": {
         "usd": "0.11"
@@ -25595,10 +25610,10 @@
       "artist_ids": [
         "7b1b0ce9-2c58-4321-a2a7-cdc94feae082"
       ],
-      "edhrec_rank": 13243,
+      "edhrec_rank": 13525,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.20"
       }
     },
     {
@@ -25637,10 +25652,10 @@
       "artist_ids": [
         "eb55171c-2342-45f4-a503-2d5a75baf752"
       ],
-      "edhrec_rank": 19847,
+      "edhrec_rank": 20050,
       "properties": [],
       "prices": {
-        "usd": "0.52"
+        "usd": "0.56"
       }
     },
     {
@@ -25682,10 +25697,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 7665,
+      "edhrec_rank": 7499,
       "properties": [],
       "prices": {
-        "usd": "3.22"
+        "usd": "3.49"
       }
     },
     {
@@ -25728,10 +25743,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 700,
+      "edhrec_rank": 703,
       "properties": [],
       "prices": {
-        "usd": "11.87"
+        "usd": "11.68"
       }
     },
     {
@@ -25791,10 +25806,10 @@
       "artist_ids": [
         "13a4bbe4-4e02-4403-8ecd-58f7744b994f"
       ],
-      "edhrec_rank": 1460,
+      "edhrec_rank": 1325,
       "properties": [],
       "prices": {
-        "usd": "2.50"
+        "usd": "2.17"
       }
     },
     {
@@ -25832,10 +25847,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 1133,
+      "edhrec_rank": 1156,
       "properties": [],
       "prices": {
-        "usd": "5.42"
+        "usd": "5.89"
       }
     },
     {
@@ -25875,10 +25890,10 @@
       "artist_ids": [
         "b40ac320-89b4-4c51-a85f-4a4b63ae614e"
       ],
-      "edhrec_rank": 597,
+      "edhrec_rank": 601,
       "properties": [],
       "prices": {
-        "usd": "58.55"
+        "usd": "62.97"
       }
     },
     {
@@ -25917,10 +25932,10 @@
       "artist_ids": [
         "d281eab4-463a-4ba8-9039-8943737960a0"
       ],
-      "edhrec_rank": 2133,
+      "edhrec_rank": 2180,
       "properties": [],
       "prices": {
-        "usd": "17.62"
+        "usd": "18.86"
       }
     },
     {
@@ -25960,10 +25975,10 @@
       "artist_ids": [
         "0c066852-6fdb-42d0-aab9-db4038850da0"
       ],
-      "edhrec_rank": 407,
+      "edhrec_rank": 418,
       "properties": [],
       "prices": {
-        "usd": "6.49"
+        "usd": "6.27"
       }
     },
     {
@@ -26021,10 +26036,10 @@
       "artist_ids": [
         "0c066852-6fdb-42d0-aab9-db4038850da0"
       ],
-      "edhrec_rank": 1015,
+      "edhrec_rank": 1039,
       "properties": [],
       "prices": {
-        "usd": "1.67"
+        "usd": "2.96"
       }
     },
     {
@@ -26066,10 +26081,10 @@
       "artist_ids": [
         "adad79bf-cd52-456a-b170-740ed8bff0fc"
       ],
-      "edhrec_rank": 3636,
+      "edhrec_rank": 3899,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.25"
       }
     },
     {
@@ -26109,7 +26124,7 @@
       "edhrec_rank": 8225,
       "properties": [],
       "prices": {
-        "usd": "19.18"
+        "usd": "20.29"
       }
     },
     {
@@ -26174,10 +26189,10 @@
       "artist_ids": [
         "ed050721-9cc1-4376-8a91-59bddbe70fe6"
       ],
-      "edhrec_rank": 2614,
+      "edhrec_rank": 2694,
       "properties": [],
       "prices": {
-        "usd": "0.50"
+        "usd": "0.91"
       }
     },
     {
@@ -26219,10 +26234,10 @@
       "artist_ids": [
         "93d65564-bf00-447b-8406-e2031f03b6b1"
       ],
-      "edhrec_rank": 10725,
+      "edhrec_rank": 10904,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.37"
       }
     },
     {
@@ -26275,10 +26290,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 2730,
+      "edhrec_rank": 2748,
       "properties": [],
       "prices": {
-        "usd": "2.09"
+        "usd": "1.99"
       }
     },
     {
@@ -26316,10 +26331,10 @@
         "e8b85539-756a-4eac-ac66-a2258d7cf547",
         "3bfc0fd7-f6ce-4c3f-a755-aaafc84ac704"
       ],
-      "edhrec_rank": 2953,
+      "edhrec_rank": 3043,
       "properties": [],
       "prices": {
-        "usd": "66.49"
+        "usd": "73.91"
       }
     },
     {
@@ -26372,10 +26387,10 @@
       "artist_ids": [
         "669b8b90-758d-4f9e-b4f7-98cd6742eb97"
       ],
-      "edhrec_rank": 7146,
+      "edhrec_rank": 7346,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.36"
       }
     },
     {
@@ -26413,10 +26428,10 @@
       "artist_ids": [
         "e8b85539-756a-4eac-ac66-a2258d7cf547"
       ],
-      "edhrec_rank": 4215,
+      "edhrec_rank": 4111,
       "properties": [],
       "prices": {
-        "usd": "3000.32"
+        "usd": "3000.48"
       }
     },
     {
@@ -26457,10 +26472,10 @@
       "artist_ids": [
         "6cb0dc0c-4362-4c21-b23a-b2d7e096aa4f"
       ],
-      "edhrec_rank": 486,
+      "edhrec_rank": 437,
       "properties": [],
       "prices": {
-        "usd": "6.31"
+        "usd": "9.34"
       }
     },
     {
@@ -26504,10 +26519,10 @@
       "artist_ids": [
         "2ae0dd12-047c-4efb-80d7-bccc3bac5fba"
       ],
-      "edhrec_rank": 1695,
+      "edhrec_rank": 1741,
       "properties": [],
       "prices": {
-        "usd": "0.52"
+        "usd": "0.60"
       }
     },
     {
@@ -26546,10 +26561,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 3258,
+      "edhrec_rank": 2954,
       "properties": [],
       "prices": {
-        "usd": "1.26"
+        "usd": "1.29"
       }
     },
     {
@@ -26576,11 +26591,11 @@
         "B",
         "W"
       ],
-      "edhrec_rank": 11676,
+      "edhrec_rank": 10889,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.20"
       }
     },
     {
@@ -26614,10 +26629,10 @@
       "artist_ids": [
         "bc1722f2-95d4-462d-948b-35be540ef4c2"
       ],
-      "edhrec_rank": 42,
+      "edhrec_rank": 40,
       "properties": [],
       "prices": {
-        "usd": "30.86"
+        "usd": "37.87"
       }
     },
     {
@@ -26655,10 +26670,10 @@
       "artist_ids": [
         "ebde5690-d401-46ba-8fd3-b9c07d5ef5a7"
       ],
-      "edhrec_rank": 8684,
+      "edhrec_rank": 8921,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.16"
       }
     },
     {
@@ -26700,10 +26715,10 @@
       "artist_ids": [
         "7c5b6391-2a5a-4b78-b19d-2b181149cb0f"
       ],
-      "edhrec_rank": 24597,
+      "edhrec_rank": 24862,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.24"
       }
     },
     {
@@ -26745,7 +26760,7 @@
       "artist_ids": [
         "7da1a585-c875-45e4-b322-5da9e8e1f651"
       ],
-      "edhrec_rank": 8126,
+      "edhrec_rank": 8269,
       "properties": [],
       "prices": {
         "usd": "0.12"
@@ -26790,10 +26805,10 @@
       "artist_ids": [
         "f8e7f8d6-6dde-4059-973c-30f1fd1bbe4e"
       ],
-      "edhrec_rank": 2516,
+      "edhrec_rank": 2486,
       "properties": [],
       "prices": {
-        "usd": "0.49"
+        "usd": "0.37"
       }
     },
     {
@@ -26832,10 +26847,10 @@
       "artist_ids": [
         "f07d73b9-52a0-4fe5-858b-61f7b42174a5"
       ],
-      "edhrec_rank": 1496,
+      "edhrec_rank": 1471,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.39"
       }
     },
     {
@@ -26874,10 +26889,10 @@
       "artist_ids": [
         "0330b5e8-2cf0-4ecb-8fd7-e20a18bdeb20"
       ],
-      "edhrec_rank": 11423,
+      "edhrec_rank": 11568,
       "properties": [],
       "prices": {
-        "usd": "0.47"
+        "usd": "0.45"
       }
     },
     {
@@ -26933,10 +26948,10 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 8234,
+      "edhrec_rank": 8424,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.29"
       }
     },
     {
@@ -26978,10 +26993,10 @@
       "artist_ids": [
         "b5f49d0d-8056-48e3-b614-090e656b4f9c"
       ],
-      "edhrec_rank": 138,
+      "edhrec_rank": 139,
       "properties": [],
       "prices": {
-        "usd": "28.83"
+        "usd": "30.36"
       }
     },
     {
@@ -27020,10 +27035,10 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 633,
+      "edhrec_rank": 651,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.34"
       }
     },
     {
@@ -27065,10 +27080,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 521,
+      "edhrec_rank": 522,
       "properties": [],
       "prices": {
-        "usd": "2.27"
+        "usd": "2.39"
       }
     },
     {
@@ -27109,10 +27124,10 @@
       "artist_ids": [
         "b40ac320-89b4-4c51-a85f-4a4b63ae614e"
       ],
-      "edhrec_rank": 193,
+      "edhrec_rank": 192,
       "properties": [],
       "prices": {
-        "usd": "2.46"
+        "usd": "2.44"
       }
     },
     {
@@ -27153,10 +27168,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 1166,
+      "edhrec_rank": 1195,
       "properties": [],
       "prices": {
-        "usd": "9.01"
+        "usd": "7.96"
       }
     },
     {
@@ -27190,10 +27205,10 @@
       "artist_ids": [
         "c4e0aa7c-a008-4d71-80ce-d5a1ca0b251b"
       ],
-      "edhrec_rank": 23797,
+      "edhrec_rank": 23914,
       "properties": [],
       "prices": {
-        "usd": "7.37"
+        "usd": "7.16"
       }
     },
     {
@@ -27227,10 +27242,10 @@
       "artist_ids": [
         "5253a25f-c71e-47d0-b4ca-5a5dcab4e405"
       ],
-      "edhrec_rank": 3135,
+      "edhrec_rank": 3116,
       "properties": [],
       "prices": {
-        "usd": "2.31"
+        "usd": "2.16"
       }
     },
     {
@@ -27267,10 +27282,10 @@
       "artist_ids": [
         "7da1a585-c875-45e4-b322-5da9e8e1f651"
       ],
-      "edhrec_rank": 10257,
+      "edhrec_rank": 10445,
       "properties": [],
       "prices": {
-        "usd": "0.56"
+        "usd": "0.59"
       }
     },
     {
@@ -27310,10 +27325,10 @@
       "artist_ids": [
         "f16f5903-990f-4ffe-88fb-fd54d0d8752b"
       ],
-      "edhrec_rank": 2786,
+      "edhrec_rank": 2727,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.36"
       }
     },
     {
@@ -27333,11 +27348,11 @@
       "oracle_text": "As this land enters, choose a basic land type. Then you may pay 2 life. If you don't, it enters tapped.\nThis land is the chosen type.",
       "color_identity": [],
       "keywords": [],
-      "edhrec_rank": 3063,
+      "edhrec_rank": 2745,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "10.95"
+        "usd": "9.18"
       }
     },
     {
@@ -27394,10 +27409,10 @@
       "artist_ids": [
         "bb2a9339-bbe4-445f-9736-3c43379ee076"
       ],
-      "edhrec_rank": 1677,
+      "edhrec_rank": 1597,
       "properties": [],
       "prices": {
-        "usd": "1.17"
+        "usd": "1.01"
       }
     },
     {
@@ -27439,10 +27454,10 @@
       "artist_ids": [
         "bc760b5e-6f98-4a17-9b12-5f4eccd12bb2"
       ],
-      "edhrec_rank": 8810,
+      "edhrec_rank": 8717,
       "properties": [],
       "prices": {
-        "usd": "0.11"
+        "usd": "0.20"
       }
     },
     {
@@ -27485,10 +27500,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 2554,
+      "edhrec_rank": 2604,
       "properties": [],
       "prices": {
-        "usd": "1.55"
+        "usd": "1.65"
       }
     },
     {
@@ -27515,11 +27530,11 @@
         "G",
         "U"
       ],
-      "edhrec_rank": 19404,
+      "edhrec_rank": 16193,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.10"
       }
     },
     {
@@ -27557,10 +27572,10 @@
       "artist_ids": [
         "9c77c81a-3b3f-4e94-a834-327d01cd6b35"
       ],
-      "edhrec_rank": 1869,
+      "edhrec_rank": 1893,
       "properties": [],
       "prices": {
-        "usd": "8.91"
+        "usd": "8.83"
       }
     },
     {
@@ -27597,10 +27612,10 @@
       "artist_ids": [
         "7b1b0ce9-2c58-4321-a2a7-cdc94feae082"
       ],
-      "edhrec_rank": 25,
+      "edhrec_rank": 27,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.26"
       }
     },
     {
@@ -27643,10 +27658,10 @@
       "artist_ids": [
         "9c77c81a-3b3f-4e94-a834-327d01cd6b35"
       ],
-      "edhrec_rank": 894,
+      "edhrec_rank": 896,
       "properties": [],
       "prices": {
-        "usd": "6.34"
+        "usd": "7.36"
       }
     },
     {
@@ -27691,7 +27706,7 @@
       "artist_ids": [
         "f28c54ff-bbe3-485d-81a4-b2cb49430a52"
       ],
-      "edhrec_rank": 372,
+      "edhrec_rank": 379,
       "properties": [],
       "prices": {
         "usd": "0.26"
@@ -27733,10 +27748,10 @@
       "artist_ids": [
         "d20672ca-0555-4238-a984-fd171d36b247"
       ],
-      "edhrec_rank": 176,
+      "edhrec_rank": 172,
       "properties": [],
       "prices": {
-        "usd": "1.93"
+        "usd": "1.36"
       }
     },
     {
@@ -27773,7 +27788,7 @@
       "artist_ids": [
         "80d03406-9efe-422d-be8f-9ab978b3aff1"
       ],
-      "edhrec_rank": 6888,
+      "edhrec_rank": 6942,
       "properties": [],
       "prices": {
         "usd": "0.62"
@@ -27818,10 +27833,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 18202,
+      "edhrec_rank": 18538,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.29"
       }
     },
     {
@@ -27859,10 +27874,10 @@
       "artist_ids": [
         "49b6270b-1b28-4e03-b503-522f97dc3a78"
       ],
-      "edhrec_rank": 4003,
+      "edhrec_rank": 4192,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.34"
       }
     },
     {
@@ -27905,10 +27920,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 557,
+      "edhrec_rank": 533,
       "properties": [],
       "prices": {
-        "usd": "0.47"
+        "usd": "0.63"
       }
     },
     {
@@ -27949,10 +27964,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 5039,
+      "edhrec_rank": 5173,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.30"
       }
     },
     {
@@ -28019,10 +28034,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 833,
+      "edhrec_rank": 843,
       "properties": [],
       "prices": {
-        "usd": "5.07"
+        "usd": "5.03"
       }
     },
     {
@@ -28064,10 +28079,10 @@
       "artist_ids": [
         "f0c43e1b-1853-4abc-8a1b-d7dda6c1d592"
       ],
-      "edhrec_rank": 8277,
+      "edhrec_rank": 8188,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.14"
       }
     },
     {
@@ -28105,7 +28120,7 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 9478,
+      "edhrec_rank": 9659,
       "properties": [],
       "prices": {
         "usd": "0.19"
@@ -28151,10 +28166,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 3082,
+      "edhrec_rank": 3172,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.29"
       }
     },
     {
@@ -28192,10 +28207,10 @@
       "artist_ids": [
         "f8e7f8d6-6dde-4059-973c-30f1fd1bbe4e"
       ],
-      "edhrec_rank": 574,
+      "edhrec_rank": 563,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.31"
       }
     },
     {
@@ -28236,10 +28251,10 @@
       "artist_ids": [
         "7b1b0ce9-2c58-4321-a2a7-cdc94feae082"
       ],
-      "edhrec_rank": 9207,
+      "edhrec_rank": 9342,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.28"
       }
     },
     {
@@ -28283,10 +28298,10 @@
       "artist_ids": [
         "c3004e2c-d372-4faa-90db-f1274e75ef41"
       ],
-      "edhrec_rank": 7031,
+      "edhrec_rank": 6914,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.08"
       }
     },
     {
@@ -28329,10 +28344,10 @@
       "artist_ids": [
         "8062d5a9-51b6-4822-933f-fa9e9dba8416"
       ],
-      "edhrec_rank": 1822,
+      "edhrec_rank": 1849,
       "properties": [],
       "prices": {
-        "usd": "8.48"
+        "usd": "8.56"
       }
     },
     {
@@ -28374,7 +28389,7 @@
       "artist_ids": [
         "30fead7c-da53-4c1b-b514-4be6e5ce487c"
       ],
-      "edhrec_rank": 18406,
+      "edhrec_rank": 18645,
       "properties": [],
       "prices": {
         "usd": "0.13"
@@ -28422,10 +28437,10 @@
       "artist_ids": [
         "81995d11-da98-4f8b-89bd-b88ca2ddb06b"
       ],
-      "edhrec_rank": 355,
+      "edhrec_rank": 358,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.34"
       }
     },
     {
@@ -28466,10 +28481,10 @@
       "artist_ids": [
         "996ad764-4ae0-4952-8bb5-5a75c9d68275"
       ],
-      "edhrec_rank": 14006,
+      "edhrec_rank": 13995,
       "properties": [],
       "prices": {
-        "usd": "0.46"
+        "usd": "0.48"
       }
     },
     {
@@ -28496,11 +28511,11 @@
         "U",
         "W"
       ],
-      "edhrec_rank": 9151,
+      "edhrec_rank": 8544,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.23"
       }
     },
     {
@@ -28523,11 +28538,11 @@
       "produced_mana": [
         "C"
       ],
-      "edhrec_rank": 16895,
+      "edhrec_rank": 14708,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.29"
       }
     },
     {
@@ -28569,10 +28584,10 @@
       "artist_ids": [
         "30fead7c-da53-4c1b-b514-4be6e5ce487c"
       ],
-      "edhrec_rank": 6812,
+      "edhrec_rank": 6976,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.41"
       }
     },
     {
@@ -28617,7 +28632,7 @@
       "edhrec_rank": 1542,
       "properties": [],
       "prices": {
-        "usd": "6.15"
+        "usd": "6.86"
       }
     },
     {
@@ -28659,10 +28674,10 @@
       "artist_ids": [
         "269392ac-4c06-4650-98e2-d49a5a7f2371"
       ],
-      "edhrec_rank": 169,
+      "edhrec_rank": 170,
       "properties": [],
       "prices": {
-        "usd": "52.10"
+        "usd": "50.81"
       }
     },
     {
@@ -28702,10 +28717,10 @@
       "artist_ids": [
         "7f1868e3-325f-4df9-8f27-a381fed4f0fc"
       ],
-      "edhrec_rank": 3095,
+      "edhrec_rank": 3013,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.34"
       }
     },
     {
@@ -28739,10 +28754,10 @@
       "artist_ids": [
         "770b4e16-de76-49ed-949f-84e6d2e06d25"
       ],
-      "edhrec_rank": 20908,
+      "edhrec_rank": 21154,
       "properties": [],
       "prices": {
-        "usd": "32.73"
+        "usd": "36.73"
       }
     },
     {
@@ -28782,10 +28797,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 5012,
+      "edhrec_rank": 5067,
       "properties": [],
       "prices": {
-        "usd": "21.75"
+        "usd": "21.99"
       }
     },
     {
@@ -28821,10 +28836,10 @@
       "artist_ids": [
         "185ea3f2-0b95-4f96-ab62-f7754ba591d8"
       ],
-      "edhrec_rank": 1505,
+      "edhrec_rank": 1562,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.35"
       }
     },
     {
@@ -28864,10 +28879,10 @@
       "artist_ids": [
         "6ab2144d-a579-4aff-bce9-e6d76427ff04"
       ],
-      "edhrec_rank": 6147,
+      "edhrec_rank": 6223,
       "properties": [],
       "prices": {
-        "usd": "4.65"
+        "usd": "4.50"
       }
     },
     {
@@ -28894,7 +28909,7 @@
         "G",
         "R"
       ],
-      "edhrec_rank": 8206,
+      "edhrec_rank": 7716,
       "is_basic": false,
       "properties": [],
       "prices": {
@@ -28927,11 +28942,11 @@
         "B",
         "R"
       ],
-      "edhrec_rank": 9253,
+      "edhrec_rank": 8765,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.24"
       }
     },
     {
@@ -28969,10 +28984,10 @@
       "artist_ids": [
         "05d233e7-4958-4f79-83e6-f9bf8b6ff78e"
       ],
-      "edhrec_rank": 5642,
+      "edhrec_rank": 5814,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.30"
       }
     },
     {
@@ -29039,10 +29054,10 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 2101,
+      "edhrec_rank": 2143,
       "properties": [],
       "prices": {
-        "usd": "1.18"
+        "usd": "1.20"
       }
     },
     {
@@ -29084,10 +29099,10 @@
       "artist_ids": [
         "d084e74b-f63a-4107-b72c-ed6250ecc93b"
       ],
-      "edhrec_rank": 639,
+      "edhrec_rank": 633,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.29"
       }
     },
     {
@@ -29132,7 +29147,7 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 368,
+      "edhrec_rank": 374,
       "properties": [],
       "prices": {
         "usd": "0.29"
@@ -29174,10 +29189,10 @@
       "artist_ids": [
         "e5f52ef5-1a2e-4128-90b0-ccc71cd47ea7"
       ],
-      "edhrec_rank": 748,
+      "edhrec_rank": 733,
       "properties": [],
       "prices": {
-        "usd": "1.39"
+        "usd": "1.35"
       }
     },
     {
@@ -29219,10 +29234,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 366,
+      "edhrec_rank": 378,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.33"
       }
     },
     {
@@ -29265,10 +29280,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 1802,
+      "edhrec_rank": 1848,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.29"
       }
     },
     {
@@ -29310,10 +29325,10 @@
       "artist_ids": [
         "30fead7c-da53-4c1b-b514-4be6e5ce487c"
       ],
-      "edhrec_rank": 16990,
+      "edhrec_rank": 17318,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.25"
       }
     },
     {
@@ -29344,11 +29359,11 @@
         "R",
         "U"
       ],
-      "edhrec_rank": 4896,
+      "edhrec_rank": 4560,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.66"
+        "usd": "0.51"
       }
     },
     {
@@ -29389,10 +29404,10 @@
       "artist_ids": [
         "bb677b1a-ce51-4888-83d6-5a94de461ff9"
       ],
-      "edhrec_rank": 91,
+      "edhrec_rank": 90,
       "properties": [],
       "prices": {
-        "usd": "30.29"
+        "usd": "32.16"
       }
     },
     {
@@ -29434,10 +29449,10 @@
       "artist_ids": [
         "63def22f-9b97-423f-8791-2c1be9f46619"
       ],
-      "edhrec_rank": 740,
+      "edhrec_rank": 715,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.32"
       }
     },
     {
@@ -29479,10 +29494,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 292,
+      "edhrec_rank": 290,
       "properties": [],
       "prices": {
-        "usd": "2.40"
+        "usd": "2.87"
       }
     },
     {
@@ -29524,10 +29539,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 73,
+      "edhrec_rank": 70,
       "properties": [],
       "prices": {
-        "usd": "17.98"
+        "usd": "18.28"
       }
     },
     {
@@ -29570,7 +29585,7 @@
       "artist_ids": [
         "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
       ],
-      "edhrec_rank": 6262,
+      "edhrec_rank": 6684,
       "properties": [],
       "prices": {
         "usd": "0.12"
@@ -29615,7 +29630,7 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 24076,
+      "edhrec_rank": 24274,
       "properties": [],
       "prices": {
         "usd": "0.36"
@@ -29647,9 +29662,12 @@
         "G",
         "U"
       ],
-      "edhrec_rank": 26642,
+      "edhrec_rank": 12939,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "0.16"
+      }
     },
     {
       "object": "card",
@@ -29733,10 +29751,10 @@
       "artist_ids": [
         "289e552e-3b58-484f-a939-64a01426e84d"
       ],
-      "edhrec_rank": 6769,
+      "edhrec_rank": 6638,
       "properties": [],
       "prices": {
-        "usd": "2.46"
+        "usd": "3.27"
       }
     },
     {
@@ -29778,10 +29796,10 @@
       "artist_ids": [
         "39fcaaac-bf5d-4c43-ae20-4cf4921a44fa"
       ],
-      "edhrec_rank": 8703,
+      "edhrec_rank": 8578,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.18"
       }
     },
     {
@@ -29848,10 +29866,10 @@
       "artist_ids": [
         "2c14303e-97a3-45fa-9bd8-59e5332a65f9"
       ],
-      "edhrec_rank": 9423,
+      "edhrec_rank": 9375,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.20"
       }
     },
     {
@@ -29891,10 +29909,10 @@
       "artist_ids": [
         "c99a114b-c679-47df-a6e9-4f9d3ad5b114"
       ],
-      "edhrec_rank": 8028,
+      "edhrec_rank": 8104,
       "properties": [],
       "prices": {
-        "usd": "17.15"
+        "usd": "18.10"
       }
     },
     {
@@ -29937,10 +29955,10 @@
       "artist_ids": [
         "bb677b1a-ce51-4888-83d6-5a94de461ff9"
       ],
-      "edhrec_rank": 2031,
+      "edhrec_rank": 2013,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.25"
       }
     },
     {
@@ -29977,10 +29995,10 @@
       "artist_ids": [
         "7be3b9e4-de9b-4a3d-884e-e67b9681d409"
       ],
-      "edhrec_rank": 7651,
+      "edhrec_rank": 7622,
       "properties": [],
       "prices": {
-        "usd": "4.61"
+        "usd": "4.65"
       }
     },
     {
@@ -30003,9 +30021,12 @@
       "produced_mana": [
         "C"
       ],
-      "edhrec_rank": 29397,
+      "edhrec_rank": 13443,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "0.50"
+      }
     },
     {
       "object": "card",
@@ -30043,10 +30064,10 @@
       "artist_ids": [
         "3a243c17-3baa-4b53-9599-645311cd7d3d"
       ],
-      "edhrec_rank": 6265,
+      "edhrec_rank": 6433,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.24"
       }
     },
     {
@@ -30087,10 +30108,10 @@
       "artist_ids": [
         "a36f01a0-e51a-48b2-a556-b9b3bc73f969"
       ],
-      "edhrec_rank": 209,
+      "edhrec_rank": 198,
       "properties": [],
       "prices": {
-        "usd": "45.04"
+        "usd": "48.79"
       }
     },
     {
@@ -30132,10 +30153,10 @@
       "artist_ids": [
         "fcd5ea36-64e0-4af0-992a-3c68a34a400f"
       ],
-      "edhrec_rank": 6284,
+      "edhrec_rank": 6316,
       "properties": [],
       "prices": {
-        "usd": "1.17"
+        "usd": "1.28"
       }
     },
     {
@@ -30177,10 +30198,10 @@
       "artist_ids": [
         "f8f662fa-d597-46a3-afb2-91d6e13243e2"
       ],
-      "edhrec_rank": 20504,
+      "edhrec_rank": 20737,
       "properties": [],
       "prices": {
-        "usd": "1.66"
+        "usd": "1.72"
       }
     },
     {
@@ -30222,10 +30243,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 23683,
+      "edhrec_rank": 23946,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.23"
       }
     },
     {
@@ -30296,10 +30317,10 @@
       "artist_ids": [
         "02e2b5de-4341-464c-8fdb-a1adbf873bc0"
       ],
-      "edhrec_rank": 582,
+      "edhrec_rank": 542,
       "properties": [],
       "prices": {
-        "usd": "1.28"
+        "usd": "1.38"
       }
     },
     {
@@ -30338,10 +30359,10 @@
       "artist_ids": [
         "b948d330-3fbd-44cc-b140-02bcc5d46f79"
       ],
-      "edhrec_rank": 11339,
+      "edhrec_rank": 11558,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.29"
       }
     },
     {
@@ -30383,10 +30404,10 @@
       "artist_ids": [
         "bc760b5e-6f98-4a17-9b12-5f4eccd12bb2"
       ],
-      "edhrec_rank": 3288,
+      "edhrec_rank": 3349,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.32"
       }
     },
     {
@@ -30429,10 +30450,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 2618,
+      "edhrec_rank": 2587,
       "properties": [],
       "prices": {
-        "usd": "11.65"
+        "usd": "10.32"
       }
     },
     {
@@ -30473,7 +30494,7 @@
       "artist_ids": [
         "22eef389-7b21-4dda-95dc-4c9a0f1bf4dd"
       ],
-      "edhrec_rank": 457,
+      "edhrec_rank": 456,
       "properties": [],
       "prices": {
         "usd": "2479.99"
@@ -30518,10 +30539,10 @@
       "artist_ids": [
         "ebde5690-d401-46ba-8fd3-b9c07d5ef5a7"
       ],
-      "edhrec_rank": 7132,
+      "edhrec_rank": 7281,
       "properties": [],
       "prices": {
-        "usd": "0.50"
+        "usd": "0.51"
       }
     },
     {
@@ -30563,10 +30584,10 @@
       "artist_ids": [
         "44c3877f-8771-43dc-9e40-f4c765f59d2e"
       ],
-      "edhrec_rank": 528,
+      "edhrec_rank": 529,
       "properties": [],
       "prices": {
-        "usd": "7.89"
+        "usd": "8.73"
       }
     },
     {
@@ -30600,10 +30621,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 38,
+      "edhrec_rank": 37,
       "properties": [],
       "prices": {
-        "usd": "106.11"
+        "usd": "122.97"
       }
     },
     {
@@ -30644,10 +30665,10 @@
       "artist_ids": [
         "a267f9bb-072b-410a-a704-50f4d19020d8"
       ],
-      "edhrec_rank": 3903,
+      "edhrec_rank": 3998,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.24"
       }
     },
     {
@@ -30689,7 +30710,7 @@
       "artist_ids": [
         "75b27b57-a475-449b-843d-15e33a39ec22"
       ],
-      "edhrec_rank": 3639,
+      "edhrec_rank": 3777,
       "properties": [],
       "prices": {
         "usd": "0.29"
@@ -30734,10 +30755,10 @@
       "artist_ids": [
         "81995d11-da98-4f8b-89bd-b88ca2ddb06b"
       ],
-      "edhrec_rank": 340,
+      "edhrec_rank": 345,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.38"
       }
     },
     {
@@ -30781,10 +30802,10 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 1998,
+      "edhrec_rank": 2004,
       "properties": [],
       "prices": {
-        "usd": "0.43"
+        "usd": "0.42"
       }
     },
     {
@@ -30826,10 +30847,10 @@
       "artist_ids": [
         "30fead7c-da53-4c1b-b514-4be6e5ce487c"
       ],
-      "edhrec_rank": 17134,
+      "edhrec_rank": 17411,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.28"
       }
     },
     {
@@ -30874,7 +30895,7 @@
       "edhrec_rank": 106,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.31"
       }
     },
     {
@@ -30916,10 +30937,10 @@
       "artist_ids": [
         "9ee9a9cc-c09e-486f-918b-69f80cbc4188"
       ],
-      "edhrec_rank": 6973,
+      "edhrec_rank": 6583,
       "properties": [],
       "prices": {
-        "usd": "2.76"
+        "usd": "2.82"
       }
     },
     {
@@ -30964,10 +30985,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 6046,
+      "edhrec_rank": 5644,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.24"
       }
     },
     {
@@ -31002,10 +31023,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 194,
+      "edhrec_rank": 195,
       "properties": [],
       "prices": {
-        "usd": "37.83"
+        "usd": "38.04"
       }
     },
     {
@@ -31043,7 +31064,7 @@
       "artist_ids": [
         "7f1868e3-325f-4df9-8f27-a381fed4f0fc"
       ],
-      "edhrec_rank": 2877,
+      "edhrec_rank": 2971,
       "properties": [],
       "prices": {
         "usd": "0.25"
@@ -31087,10 +31108,10 @@
       "artist_ids": [
         "13a4bbe4-4e02-4403-8ecd-58f7744b994f"
       ],
-      "edhrec_rank": 8362,
+      "edhrec_rank": 8550,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.22"
       }
     },
     {
@@ -31135,10 +31156,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 5007,
+      "edhrec_rank": 4687,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.18"
       }
     },
     {
@@ -31175,10 +31196,10 @@
       "artist_ids": [
         "79d6f296-1948-4a24-a2ce-a76e89057f23"
       ],
-      "edhrec_rank": 15261,
+      "edhrec_rank": 15537,
       "properties": [],
       "prices": {
-        "usd": "0.42"
+        "usd": "0.44"
       }
     },
     {
@@ -31220,10 +31241,10 @@
       "artist_ids": [
         "0bab3964-6224-4a02-acb3-f46d92dfc45d"
       ],
-      "edhrec_rank": 5358,
+      "edhrec_rank": 5082,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.17"
       }
     },
     {
@@ -31265,10 +31286,10 @@
       "artist_ids": [
         "66756146-32f8-4513-9aae-75a8e5117585"
       ],
-      "edhrec_rank": 7386,
+      "edhrec_rank": 7682,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.12"
       }
     },
     {
@@ -31306,10 +31327,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 1621,
+      "edhrec_rank": 1600,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.41"
       }
     },
     {
@@ -31351,10 +31372,10 @@
       "artist_ids": [
         "334dd388-1e26-4181-8eca-f9c097e29c5e"
       ],
-      "edhrec_rank": 1439,
+      "edhrec_rank": 1472,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.25"
       }
     },
     {
@@ -31395,10 +31416,10 @@
       "artist_ids": [
         "b6476cc7-1576-47e8-9f6a-68d05b45cf62"
       ],
-      "edhrec_rank": 2046,
+      "edhrec_rank": 1617,
       "properties": [],
       "prices": {
-        "usd": "1.38"
+        "usd": "1.14"
       }
     },
     {
@@ -31445,10 +31466,10 @@
       "artist_ids": [
         "66756146-32f8-4513-9aae-75a8e5117585"
       ],
-      "edhrec_rank": 411,
+      "edhrec_rank": 417,
       "properties": [],
       "prices": {
-        "usd": "15.38"
+        "usd": "14.04"
       }
     },
     {
@@ -31489,10 +31510,10 @@
       "artist_ids": [
         "d0b9f3cc-13fb-42b6-bc43-b034728e5c7b"
       ],
-      "edhrec_rank": 2645,
+      "edhrec_rank": 2651,
       "properties": [],
       "prices": {
-        "usd": "0.48"
+        "usd": "0.47"
       }
     },
     {
@@ -31521,11 +31542,11 @@
         "G",
         "U"
       ],
-      "edhrec_rank": 6250,
+      "edhrec_rank": 4367,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.29"
       }
     },
     {
@@ -31567,10 +31588,10 @@
       "artist_ids": [
         "e8b85539-756a-4eac-ac66-a2258d7cf547"
       ],
-      "edhrec_rank": 13030,
+      "edhrec_rank": 13132,
       "properties": [],
       "prices": {
-        "usd": "11.12"
+        "usd": "10.12"
       }
     },
     {
@@ -31612,10 +31633,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 456,
+      "edhrec_rank": 476,
       "properties": [],
       "prices": {
-        "usd": "1.55"
+        "usd": "1.09"
       }
     },
     {
@@ -31658,10 +31679,10 @@
       "artist_ids": [
         "0d8d6726-4051-445a-8374-a919aad98f38"
       ],
-      "edhrec_rank": 1860,
+      "edhrec_rank": 1907,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.23"
       }
     },
     {
@@ -31701,10 +31722,10 @@
       "artist_ids": [
         "f28c54ff-bbe3-485d-81a4-b2cb49430a52"
       ],
-      "edhrec_rank": 3480,
+      "edhrec_rank": 3672,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.33"
       }
     },
     {
@@ -31741,10 +31762,10 @@
       "artist_ids": [
         "dab52c11-0564-4207-a4a1-c1735c946a65"
       ],
-      "edhrec_rank": 16918,
+      "edhrec_rank": 17129,
       "properties": [],
       "prices": {
-        "usd": "0.70"
+        "usd": "0.81"
       }
     },
     {
@@ -31786,10 +31807,10 @@
       "artist_ids": [
         "fb7b61a8-13c5-4813-a749-9d3396801906"
       ],
-      "edhrec_rank": 8448,
+      "edhrec_rank": 8396,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.25"
       }
     },
     {
@@ -31832,10 +31853,10 @@
       "artist_ids": [
         "8df4596a-1d88-4b6a-9ce8-5c8089c3946c"
       ],
-      "edhrec_rank": 555,
+      "edhrec_rank": 562,
       "properties": [],
       "prices": {
-        "usd": "10.65"
+        "usd": "11.40"
       }
     },
     {
@@ -31881,10 +31902,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 485,
+      "edhrec_rank": 493,
       "properties": [],
       "prices": {
-        "usd": "16.64"
+        "usd": "16.39"
       }
     },
     {
@@ -31927,7 +31948,7 @@
       "artist_ids": [
         "996ad764-4ae0-4952-8bb5-5a75c9d68275"
       ],
-      "edhrec_rank": 23968,
+      "edhrec_rank": 24175,
       "properties": [],
       "prices": {
         "usd": "0.20"
@@ -31997,10 +32018,10 @@
       "artist_ids": [
         "c09ede88-a1b5-4a18-9895-dc8a965d28a5"
       ],
-      "edhrec_rank": 1911,
+      "edhrec_rank": 1858,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.31"
       }
     },
     {
@@ -32044,10 +32065,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 1008,
+      "edhrec_rank": 1033,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.29"
       }
     },
     {
@@ -32089,10 +32110,10 @@
       "artist_ids": [
         "66082c3b-a623-4d34-be51-2475214b85d3"
       ],
-      "edhrec_rank": 8151,
+      "edhrec_rank": 8119,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.27"
       }
     },
     {
@@ -32135,7 +32156,7 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 1471,
+      "edhrec_rank": 1476,
       "properties": [],
       "prices": {
         "usd": "1.01"
@@ -32163,11 +32184,11 @@
       "produced_mana": [
         "B"
       ],
-      "edhrec_rank": 7667,
+      "edhrec_rank": 6791,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.37"
       }
     },
     {
@@ -32222,7 +32243,7 @@
       "artist_ids": [
         "c3004e2c-d372-4faa-90db-f1274e75ef41"
       ],
-      "edhrec_rank": 11980,
+      "edhrec_rank": 11899,
       "properties": [],
       "prices": {
         "usd": "0.12"
@@ -32267,10 +32288,10 @@
       "artist_ids": [
         "445bd2fb-4a70-4599-87a4-83cf5979fc56"
       ],
-      "edhrec_rank": 175,
+      "edhrec_rank": 173,
       "properties": [],
       "prices": {
-        "usd": "33.93"
+        "usd": "44.02"
       }
     },
     {
@@ -32312,10 +32333,10 @@
       "artist_ids": [
         "bb677b1a-ce51-4888-83d6-5a94de461ff9"
       ],
-      "edhrec_rank": 141,
+      "edhrec_rank": 143,
       "properties": [],
       "prices": {
-        "usd": "7.97"
+        "usd": "8.40"
       }
     },
     {
@@ -32356,7 +32377,7 @@
       "edhrec_rank": 10,
       "properties": [],
       "prices": {
-        "usd": "4.56"
+        "usd": "4.75"
       }
     },
     {
@@ -32395,10 +32416,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 9823,
+      "edhrec_rank": 9758,
       "properties": [],
       "prices": {
-        "usd": "1.00"
+        "usd": "0.84"
       }
     },
     {
@@ -32439,10 +32460,10 @@
       "artist_ids": [
         "1761c216-72b5-4a9b-afee-ad47a00fe1ad"
       ],
-      "edhrec_rank": 4066,
+      "edhrec_rank": 4157,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.38"
       }
     },
     {
@@ -32499,10 +32520,10 @@
       "artist_ids": [
         "669b8b90-758d-4f9e-b4f7-98cd6742eb97"
       ],
-      "edhrec_rank": 3716,
+      "edhrec_rank": 3799,
       "properties": [],
       "prices": {
-        "usd": "1.12"
+        "usd": "1.13"
       }
     },
     {
@@ -32543,10 +32564,10 @@
       "artist_ids": [
         "8df4596a-1d88-4b6a-9ce8-5c8089c3946c"
       ],
-      "edhrec_rank": 4032,
+      "edhrec_rank": 4241,
       "properties": [],
       "prices": {
-        "usd": "0.44"
+        "usd": "0.50"
       }
     },
     {
@@ -32605,10 +32626,10 @@
       "artist_ids": [
         "a5f8354a-8b51-4e59-96b2-0e3aeae4fa1d"
       ],
-      "edhrec_rank": 2978,
+      "edhrec_rank": 3077,
       "properties": [],
       "prices": {
-        "usd": "0.83"
+        "usd": "2.56"
       }
     },
     {
@@ -32649,10 +32670,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 4036,
+      "edhrec_rank": 4229,
       "properties": [],
       "prices": {
-        "usd": "0.67"
+        "usd": "0.77"
       }
     },
     {
@@ -32693,10 +32714,10 @@
       "artist_ids": [
         "a5048cc7-438a-4378-98e4-da99b78e1db0"
       ],
-      "edhrec_rank": 4940,
+      "edhrec_rank": 5098,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.39"
       }
     },
     {
@@ -32739,10 +32760,10 @@
       "artist_ids": [
         "e4631396-f0ce-41df-9d35-a7bd1da9d5a6"
       ],
-      "edhrec_rank": 3569,
+      "edhrec_rank": 3716,
       "properties": [],
       "prices": {
-        "usd": "1.61"
+        "usd": "2.66"
       }
     },
     {
@@ -32783,10 +32804,10 @@
       "artist_ids": [
         "d072adde-7194-4bf0-b9ca-b42d8973b0ff"
       ],
-      "edhrec_rank": 4143,
+      "edhrec_rank": 4323,
       "properties": [],
       "prices": {
-        "usd": "0.53"
+        "usd": "0.46"
       }
     },
     {
@@ -32829,10 +32850,10 @@
       "artist_ids": [
         "8df4596a-1d88-4b6a-9ce8-5c8089c3946c"
       ],
-      "edhrec_rank": 4980,
+      "edhrec_rank": 4727,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.30"
       }
     },
     {
@@ -32871,10 +32892,10 @@
       "rarity": "rare",
       "artist": "Svetlin Velinov",
       "artist_ids": [],
-      "edhrec_rank": 4553,
+      "edhrec_rank": 4761,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.41"
       }
     },
     {
@@ -32915,10 +32936,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 4924,
+      "edhrec_rank": 5169,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.40"
       }
     },
     {
@@ -32988,10 +33009,10 @@
       "artist_ids": [
         "c7c15d49-f84b-4d98-9a34-e80e8347b756"
       ],
-      "edhrec_rank": 792,
+      "edhrec_rank": 739,
       "properties": [],
       "prices": {
-        "usd": "0.96"
+        "usd": "0.94"
       }
     },
     {
@@ -33033,10 +33054,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 19419,
+      "edhrec_rank": 19710,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.34"
       }
     },
     {
@@ -33078,10 +33099,10 @@
       "artist_ids": [
         "b4117364-73af-47e5-8cf0-901eeea09e01"
       ],
-      "edhrec_rank": 10627,
+      "edhrec_rank": 10924,
       "properties": [],
       "prices": {
-        "usd": "2.52"
+        "usd": "2.68"
       }
     },
     {
@@ -33123,10 +33144,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 2375,
+      "edhrec_rank": 2481,
       "properties": [],
       "prices": {
-        "usd": "0.44"
+        "usd": "0.52"
       }
     },
     {
@@ -33165,10 +33186,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 1734,
+      "edhrec_rank": 1749,
       "properties": [],
       "prices": {
-        "usd": "2.24"
+        "usd": "2.46"
       }
     },
     {
@@ -33206,10 +33227,10 @@
       "artist_ids": [
         "54366fc1-c5b1-4faa-a7a5-de2abc119de1"
       ],
-      "edhrec_rank": 14208,
+      "edhrec_rank": 14394,
       "properties": [],
       "prices": {
-        "usd": "82.77"
+        "usd": "94.87"
       }
     },
     {
@@ -33252,10 +33273,10 @@
       "artist_ids": [
         "0ebb52bf-cf87-4c03-b975-2d9df7095334"
       ],
-      "edhrec_rank": 8797,
+      "edhrec_rank": 9005,
       "properties": [],
       "prices": {
-        "usd": "0.68"
+        "usd": "0.57"
       }
     },
     {
@@ -33297,10 +33318,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 946,
+      "edhrec_rank": 996,
       "properties": [],
       "prices": {
-        "usd": "1.75"
+        "usd": "1.30"
       }
     },
     {
@@ -33341,10 +33362,10 @@
       "artist_ids": [
         "8a8ac2c8-84c9-4274-9960-a19a97f0bde5"
       ],
-      "edhrec_rank": 26560,
+      "edhrec_rank": 26529,
       "properties": [],
       "prices": {
-        "usd": "1.02"
+        "usd": "1.06"
       }
     },
     {
@@ -33384,10 +33405,10 @@
       "flavor_text": "\"The Westfolk wept, and their tears wore winding rivers into the cheek of the world.\"\n—Glem the Lonebard, \"Origins of Kholon\"",
       "artist": "Chris J. Anderson",
       "artist_ids": [],
-      "edhrec_rank": 2470,
+      "edhrec_rank": 2555,
       "properties": [],
       "prices": {
-        "usd": "1.69"
+        "usd": "1.63"
       }
     },
     {
@@ -33454,10 +33475,10 @@
       "artist_ids": [
         "aa7e89ed-d294-4633-9057-ce04dacfcfa4"
       ],
-      "edhrec_rank": 850,
+      "edhrec_rank": 846,
       "properties": [],
       "prices": {
-        "usd": "5.22"
+        "usd": "5.69"
       }
     },
     {
@@ -33499,10 +33520,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 1121,
+      "edhrec_rank": 1022,
       "properties": [],
       "prices": {
-        "usd": "22.84"
+        "usd": "24.02"
       }
     },
     {
@@ -33538,10 +33559,10 @@
       "artist_ids": [
         "b4344292-387b-4aa0-8225-13f1fbe77808"
       ],
-      "edhrec_rank": 711,
+      "edhrec_rank": 708,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.37"
       }
     },
     {
@@ -33583,10 +33604,10 @@
       "artist_ids": [
         "30fead7c-da53-4c1b-b514-4be6e5ce487c"
       ],
-      "edhrec_rank": 9293,
+      "edhrec_rank": 9487,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.24"
       }
     },
     {
@@ -33624,10 +33645,10 @@
       "artist_ids": [
         "adb9ad6d-6173-454b-8b50-a102b182548b"
       ],
-      "edhrec_rank": 3447,
+      "edhrec_rank": 3607,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.27"
       }
     },
     {
@@ -33667,10 +33688,10 @@
       "artist_ids": [
         "5c24d419-7a23-4285-932c-50727c9ede70"
       ],
-      "edhrec_rank": 5764,
+      "edhrec_rank": 5620,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.33"
       }
     },
     {
@@ -33712,10 +33733,10 @@
       "artist_ids": [
         "185ea3f2-0b95-4f96-ab62-f7754ba591d8"
       ],
-      "edhrec_rank": 210,
+      "edhrec_rank": 216,
       "properties": [],
       "prices": {
-        "usd": "3.25"
+        "usd": "2.56"
       }
     },
     {
@@ -33770,10 +33791,10 @@
       "artist_ids": [
         "0c066852-6fdb-42d0-aab9-db4038850da0"
       ],
-      "edhrec_rank": 11004,
+      "edhrec_rank": 10830,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.22"
       }
     },
     {
@@ -33807,10 +33828,10 @@
       "artist_ids": [
         "9b465bde-3656-4495-ace4-af4ce29999ed"
       ],
-      "edhrec_rank": 3353,
+      "edhrec_rank": 3375,
       "properties": [],
       "prices": {
-        "usd": "0.64"
+        "usd": "0.62"
       }
     },
     {
@@ -33851,7 +33872,7 @@
       "edhrec_rank": 19,
       "properties": [],
       "prices": {
-        "usd": "0.42"
+        "usd": "0.39"
       }
     },
     {
@@ -33892,10 +33913,10 @@
       "artist_ids": [
         "20871267-2d8a-41d5-b03a-be3d557c5734"
       ],
-      "edhrec_rank": 131,
+      "edhrec_rank": 129,
       "properties": [],
       "prices": {
-        "usd": "1.82"
+        "usd": "1.84"
       }
     },
     {
@@ -33937,10 +33958,10 @@
       "artist_ids": [
         "79d6f296-1948-4a24-a2ce-a76e89057f23"
       ],
-      "edhrec_rank": 23224,
+      "edhrec_rank": 23401,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.24"
       }
     },
     {
@@ -33981,10 +34002,10 @@
       "artist_ids": [
         "0d8d6726-4051-445a-8374-a919aad98f38"
       ],
-      "edhrec_rank": 1327,
+      "edhrec_rank": 1352,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.16"
       }
     },
     {
@@ -34027,10 +34048,10 @@
       "artist_ids": [
         "9c77c81a-3b3f-4e94-a834-327d01cd6b35"
       ],
-      "edhrec_rank": 317,
+      "edhrec_rank": 296,
       "properties": [],
       "prices": {
-        "usd": "4.78"
+        "usd": "4.85"
       }
     },
     {
@@ -34067,10 +34088,10 @@
       "artist_ids": [
         "af42a44c-8ec3-47a7-9047-5d29ddad186d"
       ],
-      "edhrec_rank": 5756,
+      "edhrec_rank": 5845,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.28"
       }
     },
     {
@@ -34109,10 +34130,10 @@
       "artist_ids": [
         "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
       ],
-      "edhrec_rank": 16363,
+      "edhrec_rank": 16462,
       "properties": [],
       "prices": {
-        "usd": "0.43"
+        "usd": "0.50"
       }
     },
     {
@@ -34143,11 +34164,11 @@
         "U",
         "W"
       ],
-      "edhrec_rank": 4093,
+      "edhrec_rank": 3678,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.26"
       }
     },
     {
@@ -34188,10 +34209,10 @@
       "artist_ids": [
         "92f6c2c1-fa57-4b52-99c4-0fd866c13dc9"
       ],
-      "edhrec_rank": 5845,
+      "edhrec_rank": 5960,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.12"
       }
     },
     {
@@ -34277,10 +34298,10 @@
       "artist_ids": [
         "05a3ac12-b25d-48e2-af5e-8a299fd3da14"
       ],
-      "edhrec_rank": 5049,
+      "edhrec_rank": 4955,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.30"
       }
     },
     {
@@ -34319,10 +34340,10 @@
       "artist_ids": [
         "c245c0ec-545f-48b9-908d-33903c52ec59"
       ],
-      "edhrec_rank": 18214,
+      "edhrec_rank": 18466,
       "properties": [],
       "prices": {
-        "usd": "0.54"
+        "usd": "0.56"
       }
     },
     {
@@ -34363,10 +34384,10 @@
       "artist_ids": [
         "9c77c81a-3b3f-4e94-a834-327d01cd6b35"
       ],
-      "edhrec_rank": 20321,
+      "edhrec_rank": 20576,
       "properties": [],
       "prices": {
-        "usd": "0.44"
+        "usd": "0.43"
       }
     },
     {
@@ -34410,10 +34431,10 @@
       "artist_ids": [
         "b0f15e74-0dd6-4156-959e-c5e30c5cdc52"
       ],
-      "edhrec_rank": 1191,
+      "edhrec_rank": 1214,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.35"
       }
     },
     {
@@ -34455,10 +34476,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 80,
+      "edhrec_rank": 78,
       "properties": [],
       "prices": {
-        "usd": "18.47"
+        "usd": "17.52"
       }
     },
     {
@@ -34500,10 +34521,10 @@
       "artist_ids": [
         "bec9ba7f-594e-4ff0-8172-9ec1fc909607"
       ],
-      "edhrec_rank": 1736,
+      "edhrec_rank": 1716,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.22"
       }
     },
     {
@@ -34537,10 +34558,10 @@
       "artist_ids": [
         "c96773f0-346c-4f7d-9271-2d98cc5d86e1"
       ],
-      "edhrec_rank": 17738,
+      "edhrec_rank": 17989,
       "properties": [],
       "prices": {
-        "usd": "5.32"
+        "usd": "5.62"
       }
     },
     {
@@ -34582,10 +34603,10 @@
       "artist_ids": [
         "a9199ae8-9891-4366-bf5b-42cfb662d840"
       ],
-      "edhrec_rank": 19768,
+      "edhrec_rank": 20053,
       "properties": [],
       "prices": {
-        "usd": "1.63"
+        "usd": "1.59"
       }
     },
     {
@@ -34627,10 +34648,10 @@
       "artist_ids": [
         "54366fc1-c5b1-4faa-a7a5-de2abc119de1"
       ],
-      "edhrec_rank": 11105,
+      "edhrec_rank": 11196,
       "properties": [],
       "prices": {
-        "usd": "0.66"
+        "usd": "0.61"
       }
     },
     {
@@ -34672,10 +34693,10 @@
       "artist_ids": [
         "93d65564-bf00-447b-8406-e2031f03b6b1"
       ],
-      "edhrec_rank": 11888,
+      "edhrec_rank": 12083,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.12"
       }
     },
     {
@@ -34713,10 +34734,10 @@
       "artist_ids": [
         "0fbd4798-76eb-46d5-a5d4-1e3a25870e34"
       ],
-      "edhrec_rank": 3560,
+      "edhrec_rank": 3624,
       "properties": [],
       "prices": {
-        "usd": "7.33"
+        "usd": "6.99"
       }
     },
     {
@@ -34753,10 +34774,10 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 2849,
+      "edhrec_rank": 2861,
       "properties": [],
       "prices": {
-        "usd": "2.77"
+        "usd": "1.73"
       }
     },
     {
@@ -34795,10 +34816,10 @@
       "artist_ids": [
         "3130411f-ddd5-4cab-a2f4-0a9c3b95a26e"
       ],
-      "edhrec_rank": 16294,
+      "edhrec_rank": 16850,
       "properties": [],
       "prices": {
-        "usd": "1.16"
+        "usd": "1.11"
       }
     },
     {
@@ -34843,10 +34864,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 492,
+      "edhrec_rank": 499,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.36"
       }
     },
     {
@@ -34885,10 +34906,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 11791,
+      "edhrec_rank": 11914,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.10"
       }
     },
     {
@@ -34927,10 +34948,10 @@
       "artist_ids": [
         "8562e6e1-f7f3-499e-8309-cc5775b37847"
       ],
-      "edhrec_rank": 6106,
+      "edhrec_rank": 6004,
       "properties": [],
       "prices": {
-        "usd": "5.35"
+        "usd": "4.73"
       }
     },
     {
@@ -34968,10 +34989,10 @@
       "artist_ids": [
         "05a3ac12-b25d-48e2-af5e-8a299fd3da14"
       ],
-      "edhrec_rank": 5912,
+      "edhrec_rank": 6142,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.29"
       }
     },
     {
@@ -35010,10 +35031,10 @@
       "artist_ids": [
         "f8f662fa-d597-46a3-afb2-91d6e13243e2"
       ],
-      "edhrec_rank": 17118,
+      "edhrec_rank": 17314,
       "properties": [],
       "prices": {
-        "usd": "0.79"
+        "usd": "0.82"
       }
     },
     {
@@ -35052,10 +35073,10 @@
       "artist_ids": [
         "3130411f-ddd5-4cab-a2f4-0a9c3b95a26e"
       ],
-      "edhrec_rank": 6637,
+      "edhrec_rank": 6500,
       "properties": [],
       "prices": {
-        "usd": "2.59"
+        "usd": "3.15"
       }
     },
     {
@@ -35094,10 +35115,10 @@
       "artist_ids": [
         "5e470014-31cb-41b0-b054-e23374484449"
       ],
-      "edhrec_rank": 8161,
+      "edhrec_rank": 7894,
       "properties": [],
       "prices": {
-        "usd": "0.48"
+        "usd": "0.55"
       }
     },
     {
@@ -35141,10 +35162,10 @@
       "artist_ids": [
         "b5516011-4722-4fc8-8542-102cecc52b71"
       ],
-      "edhrec_rank": 619,
+      "edhrec_rank": 622,
       "properties": [],
       "prices": {
-        "usd": "0.77"
+        "usd": "0.73"
       }
     },
     {
@@ -35173,11 +35194,11 @@
         "G",
         "R"
       ],
-      "edhrec_rank": 10882,
+      "edhrec_rank": 10450,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.15"
       }
     },
     {
@@ -35223,10 +35244,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 477,
+      "edhrec_rank": 490,
       "properties": [],
       "prices": {
-        "usd": "22.39"
+        "usd": "19.48"
       }
     },
     {
@@ -35267,7 +35288,7 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 470,
+      "edhrec_rank": 471,
       "properties": [],
       "prices": {
         "usd": null
@@ -35312,10 +35333,10 @@
       "artist_ids": [
         "cb577db7-7f47-4f78-8682-6eaef8a77bd1"
       ],
-      "edhrec_rank": 20903,
+      "edhrec_rank": 21111,
       "properties": [],
       "prices": {
-        "usd": "1.40"
+        "usd": "1.49"
       }
     },
     {
@@ -35352,7 +35373,7 @@
       "edhrec_rank": 49,
       "properties": [],
       "prices": {
-        "usd": "35.85"
+        "usd": "43.44"
       }
     },
     {
@@ -35395,10 +35416,10 @@
       "artist_ids": [
         "b8266529-1ffe-41e7-9969-fcf39f61426b"
       ],
-      "edhrec_rank": 912,
+      "edhrec_rank": 962,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.52"
       }
     },
     {
@@ -35436,10 +35457,10 @@
       "artist_ids": [
         "f07d73b9-52a0-4fe5-858b-61f7b42174a5"
       ],
-      "edhrec_rank": 315,
+      "edhrec_rank": 322,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.50"
       }
     },
     {
@@ -35481,10 +35502,10 @@
       "artist_ids": [
         "2c14303e-97a3-45fa-9bd8-59e5332a65f9"
       ],
-      "edhrec_rank": 2550,
+      "edhrec_rank": 2584,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.32"
       }
     },
     {
@@ -35527,10 +35548,10 @@
       "artist_ids": [
         "3130411f-ddd5-4cab-a2f4-0a9c3b95a26e"
       ],
-      "edhrec_rank": 26473,
+      "edhrec_rank": 26551,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.22"
       }
     },
     {
@@ -35557,9 +35578,12 @@
         "R",
         "U"
       ],
-      "edhrec_rank": 19834,
+      "edhrec_rank": 7270,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "2.77"
+      }
     },
     {
       "object": "card",
@@ -35595,10 +35619,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 6520,
+      "edhrec_rank": 6504,
       "properties": [],
       "prices": {
-        "usd": "57.52"
+        "usd": "64.35"
       }
     },
     {
@@ -35639,10 +35663,10 @@
       "artist_ids": [
         "0d8d6726-4051-445a-8374-a919aad98f38"
       ],
-      "edhrec_rank": 691,
+      "edhrec_rank": 704,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.24"
       }
     },
     {
@@ -35683,7 +35707,7 @@
       "artist_ids": [
         "c011318e-8503-48c1-a990-46e50aff48a0"
       ],
-      "edhrec_rank": 385,
+      "edhrec_rank": 386,
       "properties": [],
       "prices": {
         "usd": null
@@ -35721,10 +35745,10 @@
       "rarity": "rare",
       "artist": "Thomas M. Baxa",
       "artist_ids": [],
-      "edhrec_rank": 8160,
+      "edhrec_rank": 8273,
       "properties": [],
       "prices": {
-        "usd": "4.35"
+        "usd": "3.77"
       }
     },
     {
@@ -35768,10 +35792,10 @@
       "artist_ids": [
         "bec9ba7f-594e-4ff0-8172-9ec1fc909607"
       ],
-      "edhrec_rank": 2290,
+      "edhrec_rank": 2368,
       "properties": [],
       "prices": {
-        "usd": "1.92"
+        "usd": "1.59"
       }
     },
     {
@@ -35838,10 +35862,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 682,
+      "edhrec_rank": 672,
       "properties": [],
       "prices": {
-        "usd": "31.30"
+        "usd": "37.04"
       }
     },
     {
@@ -35879,10 +35903,10 @@
       "artist_ids": [
         "17bc7f55-958b-43f4-bb40-09746d05b3f9"
       ],
-      "edhrec_rank": 5144,
+      "edhrec_rank": 5309,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.26"
       }
     },
     {
@@ -35927,7 +35951,7 @@
       "edhrec_rank": 166,
       "properties": [],
       "prices": {
-        "usd": "18.55"
+        "usd": "19.80"
       }
     },
     {
@@ -35973,7 +35997,7 @@
       "edhrec_rank": 1212,
       "properties": [],
       "prices": {
-        "usd": "2.01"
+        "usd": "1.94"
       }
     },
     {
@@ -36007,10 +36031,10 @@
       "artist_ids": [
         "c4e0aa7c-a008-4d71-80ce-d5a1ca0b251b"
       ],
-      "edhrec_rank": 25554,
+      "edhrec_rank": 25650,
       "properties": [],
       "prices": {
-        "usd": "8.85"
+        "usd": "9.18"
       }
     },
     {
@@ -36053,10 +36077,10 @@
       "artist_ids": [
         "ad9811c8-6d5c-4728-9c94-a1854337b100"
       ],
-      "edhrec_rank": 23400,
+      "edhrec_rank": 23535,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.24"
       }
     },
     {
@@ -36100,10 +36124,10 @@
       "artist_ids": [
         "93bec3c0-0260-4d31-8064-5d01efb4153f"
       ],
-      "edhrec_rank": 392,
+      "edhrec_rank": 397,
       "properties": [],
       "prices": {
-        "usd": "1.08"
+        "usd": "1.22"
       }
     },
     {
@@ -36143,10 +36167,10 @@
       "artist_ids": [
         "46dc4b5e-e42c-4d65-a4f3-ad75b0f6f6dd"
       ],
-      "edhrec_rank": 9558,
+      "edhrec_rank": 9640,
       "properties": [],
       "prices": {
-        "usd": "0.59"
+        "usd": "0.68"
       }
     },
     {
@@ -36186,10 +36210,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 332,
+      "edhrec_rank": 336,
       "properties": [],
       "prices": {
-        "usd": "0.94"
+        "usd": "1.50"
       }
     },
     {
@@ -36231,7 +36255,7 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 215,
+      "edhrec_rank": 223,
       "properties": [],
       "prices": {
         "usd": "0.34"
@@ -36276,10 +36300,10 @@
       "artist_ids": [
         "eb55171c-2342-45f4-a503-2d5a75baf752"
       ],
-      "edhrec_rank": 4832,
+      "edhrec_rank": 4907,
       "properties": [],
       "prices": {
-        "usd": "3.61"
+        "usd": "3.67"
       }
     },
     {
@@ -36318,9 +36342,9 @@
       ],
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.39"
       },
-      "edhrec_rank": 5026
+      "edhrec_rank": 4619
     },
     {
       "object": "card",
@@ -36360,10 +36384,10 @@
       "artist_ids": [
         "4441fe52-9e41-40c1-9b74-8510426279ab"
       ],
-      "edhrec_rank": 1360,
+      "edhrec_rank": 1379,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.25"
       }
     },
     {
@@ -36422,10 +36446,10 @@
       "artist_ids": [
         "0c066852-6fdb-42d0-aab9-db4038850da0"
       ],
-      "edhrec_rank": 14179,
+      "edhrec_rank": 14329,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.40"
       }
     },
     {
@@ -36448,11 +36472,11 @@
       "produced_mana": [
         "C"
       ],
-      "edhrec_rank": 1873,
+      "edhrec_rank": 1671,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "2.27"
+        "usd": "2.94"
       }
     },
     {
@@ -36495,10 +36519,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 1830,
+      "edhrec_rank": 1822,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.30"
       }
     },
     {
@@ -36539,10 +36563,10 @@
       "artist_ids": [
         "89cc9475-dda2-4d13-bf88-54b92867a25c"
       ],
-      "edhrec_rank": 4615,
+      "edhrec_rank": 4734,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.34"
       }
     },
     {
@@ -36609,10 +36633,10 @@
       "artist_ids": [
         "904ed2e7-9850-4472-802f-2657c53dd4d8"
       ],
-      "edhrec_rank": 985,
+      "edhrec_rank": 978,
       "properties": [],
       "prices": {
-        "usd": "1.42"
+        "usd": "1.72"
       }
     },
     {
@@ -36651,10 +36675,10 @@
       "artist_ids": [
         "6ac24c4b-70e9-4286-8f4b-b40c92ab5847"
       ],
-      "edhrec_rank": 11110,
+      "edhrec_rank": 11242,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.28"
       }
     },
     {
@@ -36697,10 +36721,10 @@
       "artist_ids": [
         "6dd06426-59fe-4b9c-aad5-6da8446a5c3d"
       ],
-      "edhrec_rank": 1898,
+      "edhrec_rank": 1955,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.10"
       }
     },
     {
@@ -36742,10 +36766,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 523,
+      "edhrec_rank": 539,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.78"
       }
     },
     {
@@ -36784,10 +36808,10 @@
       "artist_ids": [
         "f8e7f8d6-6dde-4059-973c-30f1fd1bbe4e"
       ],
-      "edhrec_rank": 9629,
+      "edhrec_rank": 9810,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.16"
       }
     },
     {
@@ -36824,10 +36848,10 @@
       "artist_ids": [
         "04ce1c75-e30c-4b7a-8cb0-b53e4ecc2f39"
       ],
-      "edhrec_rank": 2280,
+      "edhrec_rank": 2292,
       "properties": [],
       "prices": {
-        "usd": "2.13"
+        "usd": "1.44"
       }
     },
     {
@@ -36854,11 +36878,11 @@
         "B",
         "U"
       ],
-      "edhrec_rank": 10291,
+      "edhrec_rank": 9629,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.28"
       }
     },
     {
@@ -36898,10 +36922,10 @@
       "artist_ids": [
         "1761c216-72b5-4a9b-afee-ad47a00fe1ad"
       ],
-      "edhrec_rank": 3016,
+      "edhrec_rank": 3006,
       "properties": [],
       "prices": {
-        "usd": "387.29"
+        "usd": "474.71"
       }
     },
     {
@@ -36943,10 +36967,10 @@
       "artist_ids": [
         "7be3b9e4-de9b-4a3d-884e-e67b9681d409"
       ],
-      "edhrec_rank": 414,
+      "edhrec_rank": 423,
       "properties": [],
       "prices": {
-        "usd": "2.88"
+        "usd": "3.11"
       }
     },
     {
@@ -36992,7 +37016,7 @@
       "edhrec_rank": 561,
       "properties": [],
       "prices": {
-        "usd": "11.10"
+        "usd": "12.31"
       }
     },
     {
@@ -37033,7 +37057,7 @@
       "artist_ids": [
         "269392ac-4c06-4650-98e2-d49a5a7f2371"
       ],
-      "edhrec_rank": 5374,
+      "edhrec_rank": 5481,
       "properties": [],
       "prices": {
         "usd": "0.28"
@@ -37078,10 +37102,10 @@
       "artist_ids": [
         "7e60efde-8efc-4267-89b7-8060e911d7e5"
       ],
-      "edhrec_rank": 5593,
+      "edhrec_rank": 5359,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.19"
       }
     },
     {
@@ -37124,10 +37148,10 @@
       "artist_ids": [
         "39cb50cf-0223-43c7-bd96-afb5f05c7e43"
       ],
-      "edhrec_rank": 1857,
+      "edhrec_rank": 1847,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.28"
       }
     },
     {
@@ -37169,10 +37193,10 @@
       "artist_ids": [
         "185ea3f2-0b95-4f96-ab62-f7754ba591d8"
       ],
-      "edhrec_rank": 323,
+      "edhrec_rank": 295,
       "properties": [],
       "prices": {
-        "usd": "6.18"
+        "usd": "4.06"
       }
     },
     {
@@ -37238,10 +37262,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 1314,
+      "edhrec_rank": 1337,
       "properties": [],
       "prices": {
-        "usd": "8.01"
+        "usd": "8.94"
       }
     },
     {
@@ -37281,10 +37305,10 @@
       "artist_ids": [
         "f8e7f8d6-6dde-4059-973c-30f1fd1bbe4e"
       ],
-      "edhrec_rank": 4797,
+      "edhrec_rank": 5017,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.31"
       }
     },
     {
@@ -37325,10 +37349,10 @@
       "artist_ids": [
         "9ee9a9cc-c09e-486f-918b-69f80cbc4188"
       ],
-      "edhrec_rank": 15647,
+      "edhrec_rank": 15808,
       "properties": [],
       "prices": {
-        "usd": "2.23"
+        "usd": "2.35"
       }
     },
     {
@@ -37371,10 +37395,10 @@
       "artist_ids": [
         "4b149402-618d-4f54-9db8-788e4a5bce70"
       ],
-      "edhrec_rank": 622,
+      "edhrec_rank": 625,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.33"
       }
     },
     {
@@ -37411,10 +37435,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 25948,
+      "edhrec_rank": 26271,
       "properties": [],
       "prices": {
-        "usd": "0.67"
+        "usd": "0.68"
       }
     },
     {
@@ -37457,10 +37481,10 @@
       "artist_ids": [
         "39cb50cf-0223-43c7-bd96-afb5f05c7e43"
       ],
-      "edhrec_rank": 2135,
+      "edhrec_rank": 2108,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.24"
       }
     },
     {
@@ -37501,10 +37525,10 @@
       "artist_ids": [
         "74246024-92b4-43d0-a5af-a3f9f2a35d5f"
       ],
-      "edhrec_rank": 384,
+      "edhrec_rank": 365,
       "properties": [],
       "prices": {
-        "usd": "5.45"
+        "usd": "4.16"
       }
     },
     {
@@ -37546,10 +37570,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 6679,
+      "edhrec_rank": 6824,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.23"
       }
     },
     {
@@ -37592,10 +37616,10 @@
       "artist_ids": [
         "70c20ea3-5ad6-4082-a337-6e994ae5828e"
       ],
-      "edhrec_rank": 11273,
+      "edhrec_rank": 11429,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.13"
       }
     },
     {
@@ -37638,10 +37662,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 437,
+      "edhrec_rank": 420,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.35"
       }
     },
     {
@@ -37679,10 +37703,10 @@
       "flavor_text": "The glow from within looks inviting, but woe awaits whomever finds out who stokes the fire or what simmers in the pot.",
       "artist": "Thomas M. Baxa",
       "artist_ids": [],
-      "edhrec_rank": 2104,
+      "edhrec_rank": 2057,
       "properties": [],
       "prices": {
-        "usd": "19.69"
+        "usd": "18.86"
       }
     },
     {
@@ -37724,10 +37748,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 222,
+      "edhrec_rank": 231,
       "properties": [],
       "prices": {
-        "usd": "7.10"
+        "usd": "6.96"
       }
     },
     {
@@ -37765,10 +37789,10 @@
       "artist_ids": [
         "a796c230-bbbe-425f-8ff4-6878e1cf093d"
       ],
-      "edhrec_rank": 2143,
+      "edhrec_rank": 2210,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.26"
       }
     },
     {
@@ -37808,10 +37832,10 @@
       "artist_ids": [
         "a1685587-4b55-446b-b420-c37b202ed3f1"
       ],
-      "edhrec_rank": 2182,
+      "edhrec_rank": 2233,
       "properties": [],
       "prices": {
-        "usd": "3.43"
+        "usd": "3.44"
       }
     },
     {
@@ -37853,10 +37877,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 12865,
+      "edhrec_rank": 13029,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.36"
       }
     },
     {
@@ -37898,10 +37922,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 121,
+      "edhrec_rank": 117,
       "properties": [],
       "prices": {
-        "usd": "33.16"
+        "usd": "33.86"
       }
     },
     {
@@ -37941,10 +37965,10 @@
       "artist_ids": [
         "a1685587-4b55-446b-b420-c37b202ed3f1"
       ],
-      "edhrec_rank": 598,
+      "edhrec_rank": 605,
       "properties": [],
       "prices": {
-        "usd": "37.67"
+        "usd": "42.62"
       }
     },
     {
@@ -37982,10 +38006,10 @@
       "artist_ids": [
         "0fbd4798-76eb-46d5-a5d4-1e3a25870e34"
       ],
-      "edhrec_rank": 1165,
+      "edhrec_rank": 1175,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.35"
       }
     },
     {
@@ -38027,10 +38051,10 @@
       "artist_ids": [
         "ad4caca0-8d89-44ce-a1a6-d5ca905bd6fb"
       ],
-      "edhrec_rank": 1600,
+      "edhrec_rank": 1601,
       "properties": [],
       "prices": {
-        "usd": "6.40"
+        "usd": "6.77"
       }
     },
     {
@@ -38097,10 +38121,10 @@
       "artist_ids": [
         "d20672ca-0555-4238-a984-fd171d36b247"
       ],
-      "edhrec_rank": 2039,
+      "edhrec_rank": 2014,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.40"
       }
     },
     {
@@ -38144,7 +38168,7 @@
       "artist_ids": [
         "6befd6d5-7f8d-4b7c-87e3-5511391a3359"
       ],
-      "edhrec_rank": 1144,
+      "edhrec_rank": 1164,
       "properties": [],
       "prices": {
         "usd": "0.37"
@@ -38192,10 +38216,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 6795,
+      "edhrec_rank": 6161,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.25"
       }
     },
     {
@@ -38237,10 +38261,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 276,
+      "edhrec_rank": 281,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.41"
       }
     },
     {
@@ -38281,10 +38305,10 @@
       "flavor_text": "Enter and comprehend the perfection of orchestrated life.",
       "artist": "Svetlin Velinov",
       "artist_ids": [],
-      "edhrec_rank": 1362,
+      "edhrec_rank": 1413,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.20"
       }
     },
     {
@@ -38313,11 +38337,11 @@
         "B",
         "U"
       ],
-      "edhrec_rank": 8961,
+      "edhrec_rank": 8407,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.17"
       }
     },
     {
@@ -38384,10 +38408,10 @@
       "artist_ids": [
         "3cb68fd9-a9e9-425d-85a3-c116318a880f"
       ],
-      "edhrec_rank": 182,
+      "edhrec_rank": 178,
       "properties": [],
       "prices": {
-        "usd": "6.28"
+        "usd": "7.15"
       }
     },
     {
@@ -38429,10 +38453,10 @@
       "artist_ids": [
         "30fead7c-da53-4c1b-b514-4be6e5ce487c"
       ],
-      "edhrec_rank": 3075,
+      "edhrec_rank": 3156,
       "properties": [],
       "prices": {
-        "usd": "1.46"
+        "usd": "1.77"
       }
     },
     {
@@ -38495,10 +38519,10 @@
       "artist_ids": [
         "3593dd7e-c547-4a32-81cd-7da725f60118"
       ],
-      "edhrec_rank": 9709,
+      "edhrec_rank": 9912,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.20"
       }
     },
     {
@@ -38540,10 +38564,10 @@
       "artist_ids": [
         "185ea3f2-0b95-4f96-ab62-f7754ba591d8"
       ],
-      "edhrec_rank": 7312,
+      "edhrec_rank": 7556,
       "properties": [],
       "prices": {
-        "usd": "0.08"
+        "usd": "0.13"
       }
     },
     {
@@ -38612,7 +38636,7 @@
       "artist_ids": [
         "3593dd7e-c547-4a32-81cd-7da725f60118"
       ],
-      "edhrec_rank": 10012,
+      "edhrec_rank": 10054,
       "properties": [],
       "prices": {
         "usd": "0.25"
@@ -38657,10 +38681,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 350,
+      "edhrec_rank": 348,
       "properties": [],
       "prices": {
-        "usd": "9.80"
+        "usd": "9.67"
       }
     },
     {
@@ -38685,9 +38709,12 @@
       "produced_mana": [
         "C"
       ],
-      "edhrec_rank": 27283,
+      "edhrec_rank": 13084,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "0.26"
+      }
     },
     {
       "object": "card",
@@ -38725,10 +38752,10 @@
       "artist_ids": [
         "43cdce85-e4bc-424e-ac95-fd0886b66ff3"
       ],
-      "edhrec_rank": 9951,
+      "edhrec_rank": 10051,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.08"
       }
     },
     {
@@ -38770,10 +38797,10 @@
       "artist_ids": [
         "79d6f296-1948-4a24-a2ce-a76e89057f23"
       ],
-      "edhrec_rank": 21082,
+      "edhrec_rank": 21318,
       "properties": [],
       "prices": {
-        "usd": "1.72"
+        "usd": "2.06"
       }
     },
     {
@@ -38817,10 +38844,10 @@
       "artist_ids": [
         "ce98f39c-7cdd-47e6-a520-6c50443bb4c2"
       ],
-      "edhrec_rank": 3151,
+      "edhrec_rank": 3208,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.33"
       }
     },
     {
@@ -38861,10 +38888,10 @@
       "artist_ids": [
         "0fad2c48-a56e-4a0b-b512-224f6f238f20"
       ],
-      "edhrec_rank": 1215,
+      "edhrec_rank": 1233,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.30"
       }
     },
     {
@@ -38905,7 +38932,7 @@
       "artist_ids": [
         "a267f9bb-072b-410a-a704-50f4d19020d8"
       ],
-      "edhrec_rank": 5009,
+      "edhrec_rank": 5146,
       "properties": [],
       "prices": {
         "usd": "0.27"
@@ -38966,10 +38993,10 @@
       "artist_ids": [
         "9c3e9d17-509f-485c-9360-46d897ce716b"
       ],
-      "edhrec_rank": 5019,
+      "edhrec_rank": 5052,
       "properties": [],
       "prices": {
-        "usd": "12.48"
+        "usd": "12.42"
       }
     },
     {
@@ -39010,7 +39037,7 @@
       "artist_ids": [
         "9ee9a9cc-c09e-486f-918b-69f80cbc4188"
       ],
-      "edhrec_rank": 3761,
+      "edhrec_rank": 3727,
       "properties": [],
       "prices": {
         "usd": "0.24"
@@ -39055,10 +39082,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 93,
+      "edhrec_rank": 95,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.38"
       }
     },
     {
@@ -39097,10 +39124,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 13805,
+      "edhrec_rank": 13934,
       "properties": [],
       "prices": {
-        "usd": "0.11"
+        "usd": "0.18"
       }
     },
     {
@@ -39374,10 +39401,10 @@
       "artist_ids": [
         "266ab861-ed64-4ba5-865c-f18758421cc3"
       ],
-      "edhrec_rank": 3581,
+      "edhrec_rank": 3736,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.38"
       }
     },
     {
@@ -39416,10 +39443,10 @@
       "artist_ids": [
         "2c3d2473-ff5d-4309-8194-e0b2def2ab65"
       ],
-      "edhrec_rank": 12156,
+      "edhrec_rank": 12304,
       "properties": [],
       "prices": {
-        "usd": "0.11"
+        "usd": "0.09"
       }
     },
     {
@@ -39446,11 +39473,11 @@
         "G",
         "U"
       ],
-      "edhrec_rank": 3446,
+      "edhrec_rank": 2194,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "1.09"
+        "usd": "0.56"
       }
     },
     {
@@ -39507,10 +39534,10 @@
       "artist_ids": [
         "b4344292-387b-4aa0-8225-13f1fbe77808"
       ],
-      "edhrec_rank": 922,
+      "edhrec_rank": 950,
       "properties": [],
       "prices": {
-        "usd": "2.66"
+        "usd": "3.03"
       }
     },
     {
@@ -39552,10 +39579,10 @@
       "artist_ids": [
         "5a5ee217-9d28-419a-b92a-a2376c7d18b3"
       ],
-      "edhrec_rank": 15297,
+      "edhrec_rank": 15518,
       "properties": [],
       "prices": {
-        "usd": "8.75"
+        "usd": "8.55"
       }
     },
     {
@@ -39622,10 +39649,10 @@
       "artist_ids": [
         "1885e6cb-c827-4896-994e-3d0a027d602f"
       ],
-      "edhrec_rank": 5803,
+      "edhrec_rank": 5830,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.24"
       }
     },
     {
@@ -39659,10 +39686,10 @@
       "artist_ids": [
         "d2da8270-bbdb-4c49-b84d-bf5a380e8a78"
       ],
-      "edhrec_rank": 22987,
+      "edhrec_rank": 23143,
       "properties": [],
       "prices": {
-        "usd": "10.30"
+        "usd": "10.70"
       }
     },
     {
@@ -39700,10 +39727,10 @@
       "artist_ids": [
         "0fbd4798-76eb-46d5-a5d4-1e3a25870e34"
       ],
-      "edhrec_rank": 6198,
+      "edhrec_rank": 6098,
       "properties": [],
       "prices": {
-        "usd": "0.84"
+        "usd": "0.63"
       }
     },
     {
@@ -39745,10 +39772,10 @@
       "artist_ids": [
         "608e3b85-cdd3-4d1a-8a3a-7f1ed8856f6b"
       ],
-      "edhrec_rank": 5136,
+      "edhrec_rank": 5379,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.27"
       }
     },
     {
@@ -39795,10 +39822,10 @@
       "artist_ids": [
         "aa7e89ed-d294-4633-9057-ce04dacfcfa4"
       ],
-      "edhrec_rank": 380,
+      "edhrec_rank": 391,
       "properties": [],
       "prices": {
-        "usd": "14.73"
+        "usd": "14.83"
       }
     },
     {
@@ -39852,7 +39879,7 @@
       "artist_ids": [
         "af42a44c-8ec3-47a7-9047-5d29ddad186d"
       ],
-      "edhrec_rank": 4094,
+      "edhrec_rank": 4167,
       "properties": [],
       "prices": {
         "usd": "0.26"
@@ -39894,7 +39921,7 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 13573,
+      "edhrec_rank": 13862,
       "properties": [],
       "prices": {
         "usd": "0.40"
@@ -39926,9 +39953,12 @@
         "R",
         "U"
       ],
-      "edhrec_rank": 26720,
+      "edhrec_rank": 12092,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "0.19"
+      }
     },
     {
       "object": "card",
@@ -39972,7 +40002,7 @@
       "edhrec_rank": 171,
       "properties": [],
       "prices": {
-        "usd": "15.20"
+        "usd": "16.12"
       }
     },
     {
@@ -40039,10 +40069,10 @@
       "artist_ids": [
         "bba69285-2445-4a4b-a847-59397be972ea"
       ],
-      "edhrec_rank": 2807,
+      "edhrec_rank": 2856,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.38"
       }
     },
     {
@@ -40083,10 +40113,10 @@
       "artist_ids": [
         "a1139fb8-41f5-4a9e-9a74-f662e1a23b35"
       ],
-      "edhrec_rank": 735,
+      "edhrec_rank": 744,
       "properties": [],
       "prices": {
-        "usd": "1.02"
+        "usd": "1.23"
       }
     },
     {
@@ -40128,10 +40158,10 @@
       "artist_ids": [
         "904ed2e7-9850-4472-802f-2657c53dd4d8"
       ],
-      "edhrec_rank": 184,
+      "edhrec_rank": 187,
       "properties": [],
       "prices": {
-        "usd": "21.40"
+        "usd": "15.27"
       }
     },
     {
@@ -40174,10 +40204,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 383,
+      "edhrec_rank": 392,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.24"
       }
     },
     {
@@ -40219,10 +40249,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 1590,
+      "edhrec_rank": 1572,
       "properties": [],
       "prices": {
-        "usd": "4.85"
+        "usd": "6.37"
       }
     },
     {
@@ -40280,7 +40310,7 @@
       "artist_ids": [
         "eb55171c-2342-45f4-a503-2d5a75baf752"
       ],
-      "edhrec_rank": 11674,
+      "edhrec_rank": 11871,
       "properties": [],
       "prices": {
         "usd": "1.07"
@@ -40324,10 +40354,10 @@
       "artist_ids": [
         "c3004e2c-d372-4faa-90db-f1274e75ef41"
       ],
-      "edhrec_rank": 1169,
+      "edhrec_rank": 1145,
       "properties": [],
       "prices": {
-        "usd": "0.76"
+        "usd": "0.84"
       }
     },
     {
@@ -40364,10 +40394,10 @@
       "artist_ids": [
         "a267f9bb-072b-410a-a704-50f4d19020d8"
       ],
-      "edhrec_rank": 16844,
+      "edhrec_rank": 17067,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.33"
       }
     },
     {
@@ -40407,10 +40437,10 @@
       "artist_ids": [
         "f3116c88-57f4-4fd1-95f3-cfd163977661"
       ],
-      "edhrec_rank": 10846,
+      "edhrec_rank": 11062,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.57"
       }
     },
     {
@@ -40453,10 +40483,10 @@
       "artist_ids": [
         "e4631396-f0ce-41df-9d35-a7bd1da9d5a6"
       ],
-      "edhrec_rank": 1013,
+      "edhrec_rank": 899,
       "properties": [],
       "prices": {
-        "usd": "10.58"
+        "usd": "10.75"
       }
     },
     {
@@ -40498,10 +40528,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 68,
+      "edhrec_rank": 67,
       "properties": [],
       "prices": {
-        "usd": "21.79"
+        "usd": "23.60"
       }
     },
     {
@@ -40542,10 +40572,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 13123,
+      "edhrec_rank": 13214,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.23"
       }
     },
     {
@@ -40586,10 +40616,10 @@
       "artist_ids": [
         "37970e22-9cee-44c1-af44-5ee27cf26b76"
       ],
-      "edhrec_rank": 7001,
+      "edhrec_rank": 7136,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.35"
       }
     },
     {
@@ -40631,10 +40661,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 67,
+      "edhrec_rank": 68,
       "properties": [],
       "prices": {
-        "usd": "14.21"
+        "usd": "14.36"
       }
     },
     {
@@ -40676,10 +40706,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 5349,
+      "edhrec_rank": 5457,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.14"
       }
     },
     {
@@ -40721,10 +40751,10 @@
       "artist_ids": [
         "e31f5891-08f7-4e5a-bac9-8b4570b8c1ab"
       ],
-      "edhrec_rank": 220,
+      "edhrec_rank": 204,
       "properties": [],
       "prices": {
-        "usd": "5.17"
+        "usd": "3.94"
       }
     },
     {
@@ -40766,10 +40796,10 @@
       "artist_ids": [
         "b6476cc7-1576-47e8-9f6a-68d05b45cf62"
       ],
-      "edhrec_rank": 8723,
+      "edhrec_rank": 8572,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.26"
       }
     },
     {
@@ -40841,10 +40871,10 @@
       "artist_ids": [
         "d48dd097-720d-476a-8722-6a02854ae28b"
       ],
-      "edhrec_rank": 1948,
+      "edhrec_rank": 1923,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.35"
       }
     },
     {
@@ -40882,10 +40912,10 @@
       "artist_ids": [
         "63ac31a8-dd1a-4679-9f82-ece89429a084"
       ],
-      "edhrec_rank": 516,
+      "edhrec_rank": 519,
       "properties": [],
       "prices": {
-        "usd": "63.28"
+        "usd": "64.76"
       }
     },
     {
@@ -40944,10 +40974,10 @@
       "artist_ids": [
         "0c066852-6fdb-42d0-aab9-db4038850da0"
       ],
-      "edhrec_rank": 12950,
+      "edhrec_rank": 13181,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.40"
       }
     },
     {
@@ -40991,10 +41021,10 @@
       "artist_ids": [
         "d084e74b-f63a-4107-b72c-ed6250ecc93b"
       ],
-      "edhrec_rank": 7235,
+      "edhrec_rank": 4355,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.21"
       }
     },
     {
@@ -41064,10 +41094,10 @@
       "artist_ids": [
         "93bec3c0-0260-4d31-8064-5d01efb4153f"
       ],
-      "edhrec_rank": 1260,
+      "edhrec_rank": 1250,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.38"
       }
     },
     {
@@ -41109,10 +41139,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 4877,
+      "edhrec_rank": 4928,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.23"
       }
     },
     {
@@ -41151,10 +41181,10 @@
       "artist_ids": [
         "2e6a0611-9411-4ba4-98e3-c0e18cbf9f83"
       ],
-      "edhrec_rank": 18797,
+      "edhrec_rank": 19003,
       "properties": [],
       "prices": {
-        "usd": "0.42"
+        "usd": "0.45"
       }
     },
     {
@@ -41183,11 +41213,11 @@
         "G",
         "W"
       ],
-      "edhrec_rank": 10640,
+      "edhrec_rank": 10170,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.11"
+        "usd": "0.17"
       }
     },
     {
@@ -41229,10 +41259,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 85,
+      "edhrec_rank": 83,
       "properties": [],
       "prices": {
-        "usd": "0.76"
+        "usd": "0.71"
       }
     },
     {
@@ -41275,10 +41305,10 @@
       "artist_ids": [
         "b845b8ee-aeea-4822-bcf9-7230625ac95c"
       ],
-      "edhrec_rank": 20904,
+      "edhrec_rank": 21155,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.28"
       }
     },
     {
@@ -41320,10 +41350,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 5116,
+      "edhrec_rank": 5352,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.32"
       }
     },
     {
@@ -41365,7 +41395,7 @@
       "artist_ids": [
         "3bfc0fd7-f6ce-4c3f-a755-aaafc84ac704"
       ],
-      "edhrec_rank": 159,
+      "edhrec_rank": 158,
       "properties": [],
       "prices": {
         "usd": "18.07"
@@ -41395,11 +41425,11 @@
         "R",
         "W"
       ],
-      "edhrec_rank": 9057,
+      "edhrec_rank": 8422,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.25"
       }
     },
     {
@@ -41441,10 +41471,10 @@
       "artist_ids": [
         "f8e7f8d6-6dde-4059-973c-30f1fd1bbe4e"
       ],
-      "edhrec_rank": 1486,
+      "edhrec_rank": 1474,
       "properties": [],
       "prices": {
-        "usd": "3.28"
+        "usd": "4.06"
       }
     },
     {
@@ -41486,10 +41516,10 @@
       "artist_ids": [
         "d54c4a1a-c0c5-4834-84db-125d341f3ad8"
       ],
-      "edhrec_rank": 1065,
+      "edhrec_rank": 968,
       "properties": [],
       "prices": {
-        "usd": "11.76"
+        "usd": "11.25"
       }
     },
     {
@@ -41556,10 +41586,10 @@
       "artist_ids": [
         "c40c8ec8-d8b3-48a5-8de2-a7c96cbded5b"
       ],
-      "edhrec_rank": 775,
+      "edhrec_rank": 734,
       "properties": [],
       "prices": {
-        "usd": "0.86"
+        "usd": "0.99"
       }
     },
     {
@@ -41601,10 +41631,10 @@
       "artist_ids": [
         "185ea3f2-0b95-4f96-ab62-f7754ba591d8"
       ],
-      "edhrec_rank": 314,
+      "edhrec_rank": 292,
       "properties": [],
       "prices": {
-        "usd": "7.79"
+        "usd": "5.81"
       }
     },
     {
@@ -41646,10 +41676,10 @@
       "artist_ids": [
         "dab52c11-0564-4207-a4a1-c1735c946a65"
       ],
-      "edhrec_rank": 434,
+      "edhrec_rank": 439,
       "properties": [],
       "prices": {
-        "usd": "2.26"
+        "usd": "2.62"
       }
     },
     {
@@ -41691,10 +41721,10 @@
       "artist_ids": [
         "30fead7c-da53-4c1b-b514-4be6e5ce487c"
       ],
-      "edhrec_rank": 1711,
+      "edhrec_rank": 1766,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.37"
       }
     },
     {
@@ -41735,10 +41765,10 @@
       "artist_ids": [
         "f7183a8d-4833-4a89-8da9-f6024851982b"
       ],
-      "edhrec_rank": 5947,
+      "edhrec_rank": 6027,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.46"
       }
     },
     {
@@ -41780,10 +41810,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 83,
+      "edhrec_rank": 86,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.40"
       }
     },
     {
@@ -41822,10 +41852,10 @@
       "artist_ids": [
         "7f1868e3-325f-4df9-8f27-a381fed4f0fc"
       ],
-      "edhrec_rank": 4339,
+      "edhrec_rank": 4273,
       "properties": [],
       "prices": {
-        "usd": "0.79"
+        "usd": "0.87"
       }
     },
     {
@@ -41868,10 +41898,10 @@
       "artist_ids": [
         "002c739e-aa1f-4c1d-921b-37cb2d1b1c5b"
       ],
-      "edhrec_rank": 1075,
+      "edhrec_rank": 1048,
       "properties": [],
       "prices": {
-        "usd": "12.30"
+        "usd": "12.57"
       }
     },
     {
@@ -41913,10 +41943,10 @@
       "artist_ids": [
         "8089db55-5105-47b0-8c64-f320e08c97f0"
       ],
-      "edhrec_rank": 1769,
+      "edhrec_rank": 1720,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.23"
       }
     },
     {
@@ -41957,10 +41987,10 @@
       "artist_ids": [
         "8062d5a9-51b6-4822-933f-fa9e9dba8416"
       ],
-      "edhrec_rank": 135,
+      "edhrec_rank": 136,
       "properties": [],
       "prices": {
-        "usd": "2.11"
+        "usd": "1.97"
       }
     },
     {
@@ -42014,10 +42044,10 @@
       "artist_ids": [
         "9cb65d6f-8851-4d56-9add-9eefa274bd1b"
       ],
-      "edhrec_rank": 3109,
+      "edhrec_rank": 3178,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.31"
       }
     },
     {
@@ -42059,7 +42089,7 @@
       "artist_ids": [
         "810677e5-a502-4c03-b726-78cd808a75d4"
       ],
-      "edhrec_rank": 905,
+      "edhrec_rank": 858,
       "properties": [],
       "prices": {
         "usd": "0.35"
@@ -42148,10 +42178,10 @@
       "artist_ids": [
         "44c3877f-8771-43dc-9e40-f4c765f59d2e"
       ],
-      "edhrec_rank": 7152,
+      "edhrec_rank": 7151,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.30"
       }
     },
     {
@@ -42193,10 +42223,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 16646,
+      "edhrec_rank": 16996,
       "properties": [],
       "prices": {
-        "usd": "0.11"
+        "usd": "0.14"
       }
     },
     {
@@ -42239,10 +42269,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 2501,
+      "edhrec_rank": 2564,
       "properties": [],
       "prices": {
-        "usd": "0.42"
+        "usd": "0.37"
       }
     },
     {
@@ -42282,10 +42312,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 2458,
+      "edhrec_rank": 2193,
       "properties": [],
       "prices": {
-        "usd": "4.88"
+        "usd": "4.69"
       }
     },
     {
@@ -42326,10 +42356,10 @@
       "artist_ids": [
         "30fead7c-da53-4c1b-b514-4be6e5ce487c"
       ],
-      "edhrec_rank": 11556,
+      "edhrec_rank": 11847,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.20"
       }
     },
     {
@@ -42368,10 +42398,10 @@
       "artist_ids": [
         "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
       ],
-      "edhrec_rank": 14242,
+      "edhrec_rank": 14251,
       "properties": [],
       "prices": {
-        "usd": "1.77"
+        "usd": "2.19"
       }
     },
     {
@@ -42407,10 +42437,10 @@
       "flavor_text": "Where scavengers nest in hollowed-out rib cages and chittering crawlers peer from empty eye sockets, few dare to trespass.",
       "artist": "Thomas M. Baxa",
       "artist_ids": [],
-      "edhrec_rank": 1078,
+      "edhrec_rank": 1035,
       "properties": [],
       "prices": {
-        "usd": "5.15"
+        "usd": "5.80"
       }
     },
     {
@@ -42451,7 +42481,7 @@
       "artist_ids": [
         "0d8d6726-4051-445a-8374-a919aad98f38"
       ],
-      "edhrec_rank": 989,
+      "edhrec_rank": 1005,
       "properties": [],
       "prices": {
         "usd": "0.20"
@@ -42495,7 +42525,7 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 439,
+      "edhrec_rank": 440,
       "properties": [],
       "prices": {
         "usd": null
@@ -42540,10 +42570,10 @@
       "artist_ids": [
         "b4117364-73af-47e5-8cf0-901eeea09e01"
       ],
-      "edhrec_rank": 427,
+      "edhrec_rank": 421,
       "properties": [],
       "prices": {
-        "usd": "1.57"
+        "usd": "1.59"
       }
     },
     {
@@ -42585,10 +42615,10 @@
       "artist_ids": [
         "70c20ea3-5ad6-4082-a337-6e994ae5828e"
       ],
-      "edhrec_rank": 481,
+      "edhrec_rank": 496,
       "properties": [],
       "prices": {
-        "usd": "1.20"
+        "usd": "1.25"
       }
     },
     {
@@ -42630,10 +42660,10 @@
       "artist_ids": [
         "1952c90b-a5a7-4328-9f7c-e11064f59daf"
       ],
-      "edhrec_rank": 495,
+      "edhrec_rank": 500,
       "properties": [],
       "prices": {
-        "usd": "2.26"
+        "usd": "2.23"
       }
     },
     {
@@ -42675,10 +42705,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 435,
+      "edhrec_rank": 424,
       "properties": [],
       "prices": {
-        "usd": "1.08"
+        "usd": "1.07"
       }
     },
     {
@@ -42720,10 +42750,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 239,
+      "edhrec_rank": 242,
       "properties": [],
       "prices": {
-        "usd": "12.04"
+        "usd": "10.48"
       }
     },
     {
@@ -42765,10 +42795,10 @@
       "artist_ids": [
         "f07d73b9-52a0-4fe5-858b-61f7b42174a5"
       ],
-      "edhrec_rank": 595,
+      "edhrec_rank": 585,
       "properties": [],
       "prices": {
-        "usd": "34.65"
+        "usd": "33.97"
       }
     },
     {
@@ -42837,7 +42867,7 @@
       "artist_ids": [
         "d20672ca-0555-4238-a984-fd171d36b247"
       ],
-      "edhrec_rank": 3189,
+      "edhrec_rank": 3180,
       "properties": [],
       "prices": {
         "usd": "0.33"
@@ -42882,10 +42912,10 @@
       "artist_ids": [
         "a5048cc7-438a-4378-98e4-da99b78e1db0"
       ],
-      "edhrec_rank": 1262,
+      "edhrec_rank": 1277,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.25"
       }
     },
     {
@@ -42929,10 +42959,10 @@
       "artist_ids": [
         "a5048cc7-438a-4378-98e4-da99b78e1db0"
       ],
-      "edhrec_rank": 3062,
+      "edhrec_rank": 3125,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.31"
       }
     },
     {
@@ -42973,10 +43003,10 @@
       "artist_ids": [
         "bb677b1a-ce51-4888-83d6-5a94de461ff9"
       ],
-      "edhrec_rank": 8424,
+      "edhrec_rank": 8724,
       "properties": [],
       "prices": {
-        "usd": "0.61"
+        "usd": "0.64"
       }
     },
     {
@@ -43018,10 +43048,10 @@
       "artist_ids": [
         "996ad764-4ae0-4952-8bb5-5a75c9d68275"
       ],
-      "edhrec_rank": 2662,
+      "edhrec_rank": 2599,
       "properties": [],
       "prices": {
-        "usd": "18.31"
+        "usd": "18.28"
       }
     },
     {
@@ -43048,7 +43078,7 @@
         "R",
         "U"
       ],
-      "edhrec_rank": 19779,
+      "edhrec_rank": 16457,
       "is_basic": false,
       "properties": [],
       "prices": {
@@ -43090,10 +43120,10 @@
       "artist_ids": [
         "d82b1138-76d3-49f7-9d8c-bc2e2d3e0b0a"
       ],
-      "edhrec_rank": 3701,
+      "edhrec_rank": 3766,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.21"
       }
     },
     {
@@ -43132,7 +43162,7 @@
       "artist_ids": [
         "9c77c81a-3b3f-4e94-a834-327d01cd6b35"
       ],
-      "edhrec_rank": 14722,
+      "edhrec_rank": 14981,
       "properties": [],
       "prices": {
         "usd": "0.10"
@@ -43177,10 +43207,10 @@
       "artist_ids": [
         "09922e8b-c57f-4374-97e4-c0b86b66ef4b"
       ],
-      "edhrec_rank": 17281,
+      "edhrec_rank": 17471,
       "properties": [],
       "prices": {
-        "usd": "6.27"
+        "usd": "11.63"
       }
     },
     {
@@ -43225,7 +43255,7 @@
       "edhrec_rank": 82,
       "properties": [],
       "prices": {
-        "usd": "15.51"
+        "usd": "15.42"
       }
     },
     {
@@ -43268,10 +43298,10 @@
       "artist_ids": [
         "e5f52ef5-1a2e-4128-90b0-ccc71cd47ea7"
       ],
-      "edhrec_rank": 467,
+      "edhrec_rank": 484,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.28"
       }
     },
     {
@@ -43314,10 +43344,10 @@
       "artist_ids": [
         "e956bacc-077d-4c12-b6bc-ba798b718af9"
       ],
-      "edhrec_rank": 308,
+      "edhrec_rank": 330,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.34"
       }
     },
     {
@@ -43358,10 +43388,10 @@
       "rarity": "rare",
       "artist": "Svetlin Velinov",
       "artist_ids": [],
-      "edhrec_rank": 296,
+      "edhrec_rank": 303,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.30"
       }
     },
     {
@@ -43404,10 +43434,10 @@
       "artist_ids": [
         "81995d11-da98-4f8b-89bd-b88ca2ddb06b"
       ],
-      "edhrec_rank": 265,
+      "edhrec_rank": 270,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.40"
       }
     },
     {
@@ -43450,10 +43480,10 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 346,
+      "edhrec_rank": 343,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.35"
       }
     },
     {
@@ -43496,10 +43526,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 398,
+      "edhrec_rank": 415,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.28"
       }
     },
     {
@@ -43542,10 +43572,10 @@
       "artist_ids": [
         "81995d11-da98-4f8b-89bd-b88ca2ddb06b"
       ],
-      "edhrec_rank": 294,
+      "edhrec_rank": 297,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.38"
       }
     },
     {
@@ -43588,10 +43618,10 @@
       "artist_ids": [
         "81995d11-da98-4f8b-89bd-b88ca2ddb06b"
       ],
-      "edhrec_rank": 464,
+      "edhrec_rank": 479,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.42"
       }
     },
     {
@@ -43634,10 +43664,10 @@
       "artist_ids": [
         "0fad2c48-a56e-4a0b-b512-224f6f238f20"
       ],
-      "edhrec_rank": 272,
+      "edhrec_rank": 275,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.37"
       }
     },
     {
@@ -43678,10 +43708,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 2488,
+      "edhrec_rank": 2489,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.34"
       }
     },
     {
@@ -43719,10 +43749,10 @@
       "artist_ids": [
         "770b4e16-de76-49ed-949f-84e6d2e06d25"
       ],
-      "edhrec_rank": 70,
+      "edhrec_rank": 74,
       "properties": [],
       "prices": {
-        "usd": "0.59"
+        "usd": "0.78"
       }
     },
     {
@@ -43765,10 +43795,10 @@
       "artist_ids": [
         "af42a44c-8ec3-47a7-9047-5d29ddad186d"
       ],
-      "edhrec_rank": 287,
+      "edhrec_rank": 288,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.34"
       }
     },
     {
@@ -43810,10 +43840,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 7064,
+      "edhrec_rank": 7076,
       "properties": [],
       "prices": {
-        "usd": "1.81"
+        "usd": "1.76"
       }
     },
     {
@@ -43850,10 +43880,10 @@
       "artist_ids": [
         "0ebb52bf-cf87-4c03-b975-2d9df7095334"
       ],
-      "edhrec_rank": 11100,
+      "edhrec_rank": 11269,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.24"
       }
     },
     {
@@ -43890,10 +43920,10 @@
       "artist_ids": [
         "70c20ea3-5ad6-4082-a337-6e994ae5828e"
       ],
-      "edhrec_rank": 1906,
+      "edhrec_rank": 1904,
       "properties": [],
       "prices": {
-        "usd": "3.35"
+        "usd": "3.55"
       }
     },
     {
@@ -43973,10 +44003,10 @@
       "artist_ids": [
         "14a1de4b-1237-4e7b-8868-b71e87c9a46e"
       ],
-      "edhrec_rank": 24554,
+      "edhrec_rank": 24556,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.30"
       }
     },
     {
@@ -44010,10 +44040,10 @@
       "artist_ids": [
         "14a1de4b-1237-4e7b-8868-b71e87c9a46e"
       ],
-      "edhrec_rank": 11566,
+      "edhrec_rank": 11711,
       "properties": [],
       "prices": {
-        "usd": "23.01"
+        "usd": "25.41"
       }
     },
     {
@@ -44053,10 +44083,10 @@
       "artist_ids": [
         "185ea3f2-0b95-4f96-ab62-f7754ba591d8"
       ],
-      "edhrec_rank": 7606,
+      "edhrec_rank": 7806,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.14"
       }
     },
     {
@@ -44093,10 +44123,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 15782,
+      "edhrec_rank": 15685,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.20"
       }
     },
     {
@@ -44135,10 +44165,10 @@
       "artist_ids": [
         "8089db55-5105-47b0-8c64-f320e08c97f0"
       ],
-      "edhrec_rank": 1175,
+      "edhrec_rank": 1199,
       "properties": [],
       "prices": {
-        "usd": "7.08"
+        "usd": "9.11"
       }
     },
     {
@@ -44178,10 +44208,10 @@
       "artist_ids": [
         "bc760b5e-6f98-4a17-9b12-5f4eccd12bb2"
       ],
-      "edhrec_rank": 6991,
+      "edhrec_rank": 7163,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.24"
       }
     },
     {
@@ -44221,10 +44251,10 @@
       "artist_ids": [
         "8089db55-5105-47b0-8c64-f320e08c97f0"
       ],
-      "edhrec_rank": 6543,
+      "edhrec_rank": 6690,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.18"
       }
     },
     {
@@ -44280,10 +44310,10 @@
       "artist_ids": [
         "13a4bbe4-4e02-4403-8ecd-58f7744b994f"
       ],
-      "edhrec_rank": 4085,
+      "edhrec_rank": 3870,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.32"
       }
     },
     {
@@ -44328,10 +44358,10 @@
       "artist_ids": [
         "bb677b1a-ce51-4888-83d6-5a94de461ff9"
       ],
-      "edhrec_rank": 1484,
+      "edhrec_rank": 1530,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.28"
       }
     },
     {
@@ -44371,10 +44401,10 @@
       "artist_ids": [
         "bb677b1a-ce51-4888-83d6-5a94de461ff9"
       ],
-      "edhrec_rank": 6647,
+      "edhrec_rank": 6812,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.15"
       }
     },
     {
@@ -44411,10 +44441,10 @@
       "artist_ids": [
         "91d65465-e8a6-4a4e-8b0e-0e07466cfa0f"
       ],
-      "edhrec_rank": 13008,
+      "edhrec_rank": 13172,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.26"
       }
     },
     {
@@ -44457,10 +44487,10 @@
       "artist_ids": [
         "adad79bf-cd52-456a-b170-740ed8bff0fc"
       ],
-      "edhrec_rank": 866,
+      "edhrec_rank": 875,
       "properties": [],
       "prices": {
-        "usd": "0.66"
+        "usd": "1.51"
       }
     },
     {
@@ -44504,10 +44534,10 @@
       "artist_ids": [
         "a662cb71-4770-4b49-8b03-2cf8497049a7"
       ],
-      "edhrec_rank": 5538,
+      "edhrec_rank": 5640,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.35"
       }
     },
     {
@@ -44565,10 +44595,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 1104,
+      "edhrec_rank": 1136,
       "properties": [],
       "prices": {
-        "usd": "4.48"
+        "usd": "4.05"
       }
     },
     {
@@ -44608,10 +44638,10 @@
       "artist_ids": [
         "e31f5891-08f7-4e5a-bac9-8b4570b8c1ab"
       ],
-      "edhrec_rank": 8585,
+      "edhrec_rank": 8812,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.24"
       }
     },
     {
@@ -44645,7 +44675,7 @@
       "artist_ids": [
         "3de0bcf5-44b7-4c1e-9040-04c5396e79b0"
       ],
-      "edhrec_rank": 8971,
+      "edhrec_rank": 8945,
       "properties": [],
       "prices": {
         "usd": "2899.99"
@@ -44695,10 +44725,10 @@
       "artist_ids": [
         "3605d81f-5c97-4958-9dcc-d44a85e10305"
       ],
-      "edhrec_rank": 758,
+      "edhrec_rank": 782,
       "properties": [],
       "prices": {
-        "usd": "8.31"
+        "usd": "7.41"
       }
     },
     {
@@ -44736,10 +44766,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 541,
+      "edhrec_rank": 552,
       "properties": [],
       "prices": {
-        "usd": "0.65"
+        "usd": "0.55"
       }
     },
     {
@@ -44783,10 +44813,10 @@
       "artist_ids": [
         "a5048cc7-438a-4378-98e4-da99b78e1db0"
       ],
-      "edhrec_rank": 4394,
+      "edhrec_rank": 4447,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.31"
       }
     },
     {
@@ -44828,10 +44858,10 @@
       "artist_ids": [
         "a662cb71-4770-4b49-8b03-2cf8497049a7"
       ],
-      "edhrec_rank": 862,
+      "edhrec_rank": 808,
       "properties": [],
       "prices": {
-        "usd": "4.95"
+        "usd": "5.20"
       }
     },
     {
@@ -44872,10 +44902,10 @@
       "artist_ids": [
         "0d8d6726-4051-445a-8374-a919aad98f38"
       ],
-      "edhrec_rank": 997,
+      "edhrec_rank": 1023,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.12"
       }
     },
     {
@@ -44925,10 +44955,10 @@
       "artist_ids": [
         "e31f5891-08f7-4e5a-bac9-8b4570b8c1ab"
       ],
-      "edhrec_rank": 4432,
+      "edhrec_rank": 4496,
       "properties": [],
       "prices": {
-        "usd": "0.71"
+        "usd": "0.76"
       }
     },
     {
@@ -44969,10 +44999,10 @@
       "artist_ids": [
         "5ce7b3bd-53d2-49e6-b504-37191e8e9b17"
       ],
-      "edhrec_rank": 13889,
+      "edhrec_rank": 14162,
       "properties": [],
       "prices": {
-        "usd": "4.62"
+        "usd": "4.73"
       }
     },
     {
@@ -45014,10 +45044,10 @@
       "artist_ids": [
         "8456c8ad-78c4-4ce0-9d5d-8a0cf994a361"
       ],
-      "edhrec_rank": 189,
+      "edhrec_rank": 184,
       "properties": [],
       "prices": {
-        "usd": "22.24"
+        "usd": "23.90"
       }
     },
     {
@@ -45061,10 +45091,10 @@
       "artist_ids": [
         "3593dd7e-c547-4a32-81cd-7da725f60118"
       ],
-      "edhrec_rank": 1192,
+      "edhrec_rank": 1209,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.22"
       }
     },
     {
@@ -45108,10 +45138,10 @@
       "artist_ids": [
         "e24bc1d0-446b-45e0-b215-89f581837aa4"
       ],
-      "edhrec_rank": 1234,
+      "edhrec_rank": 1213,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.22"
       }
     },
     {
@@ -45155,7 +45185,7 @@
       "artist_ids": [
         "bb677b1a-ce51-4888-83d6-5a94de461ff9"
       ],
-      "edhrec_rank": 1086,
+      "edhrec_rank": 1080,
       "properties": [],
       "prices": {
         "usd": "0.17"
@@ -45202,10 +45232,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 1042,
+      "edhrec_rank": 1028,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.20"
       }
     },
     {
@@ -45249,10 +45279,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 1240,
+      "edhrec_rank": 1228,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.23"
       }
     },
     {
@@ -45294,10 +45324,10 @@
       "artist_ids": [
         "9c3e9d17-509f-485c-9360-46d897ce716b"
       ],
-      "edhrec_rank": 17772,
+      "edhrec_rank": 18079,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.20"
       }
     },
     {
@@ -45351,10 +45381,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 4532,
+      "edhrec_rank": 4625,
       "properties": [],
       "prices": {
-        "usd": "0.50"
+        "usd": "0.49"
       }
     },
     {
@@ -45397,10 +45427,10 @@
       "artist_ids": [
         "8456c8ad-78c4-4ce0-9d5d-8a0cf994a361"
       ],
-      "edhrec_rank": 635,
+      "edhrec_rank": 626,
       "properties": [],
       "prices": {
-        "usd": "14.92"
+        "usd": "16.06"
       }
     },
     {
@@ -45442,10 +45472,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 8415,
+      "edhrec_rank": 8559,
       "properties": [],
       "prices": {
-        "usd": "0.05"
+        "usd": "0.06"
       }
     },
     {
@@ -45488,10 +45518,10 @@
       "artist_ids": [
         "70c20ea3-5ad6-4082-a337-6e994ae5828e"
       ],
-      "edhrec_rank": 23101,
+      "edhrec_rank": 23343,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.19"
       }
     },
     {
@@ -45532,10 +45562,10 @@
       "artist_ids": [
         "14a1de4b-1237-4e7b-8868-b71e87c9a46e"
       ],
-      "edhrec_rank": 28929,
+      "edhrec_rank": 29078,
       "properties": [],
       "prices": {
-        "usd": "1.06"
+        "usd": "1.02"
       }
     },
     {
@@ -45578,10 +45608,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 21002,
+      "edhrec_rank": 21236,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.18"
       }
     },
     {
@@ -45610,9 +45640,12 @@
         "B",
         "G"
       ],
-      "edhrec_rank": 25528,
+      "edhrec_rank": 10677,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "0.21"
+      }
     },
     {
       "object": "card",
@@ -45651,10 +45684,10 @@
       "artist_ids": [
         "1ba1c5be-7a22-46e0-912c-79c87c197bdc"
       ],
-      "edhrec_rank": 5717,
+      "edhrec_rank": 5913,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.23"
       }
     },
     {
@@ -45694,10 +45727,10 @@
       "artist_ids": [
         "3de0bcf5-44b7-4c1e-9040-04c5396e79b0"
       ],
-      "edhrec_rank": 17919,
+      "edhrec_rank": 18034,
       "properties": [],
       "prices": {
-        "usd": "6.89"
+        "usd": "7.07"
       }
     },
     {
@@ -45738,10 +45771,10 @@
       "artist_ids": [
         "9033cb21-6f15-4abe-9a61-4bacf1e8800e"
       ],
-      "edhrec_rank": 3255,
+      "edhrec_rank": 3273,
       "properties": [],
       "prices": {
-        "usd": "1.68"
+        "usd": "1.96"
       }
     },
     {
@@ -45782,10 +45815,10 @@
       "artist_ids": [
         "fb7b61a8-13c5-4813-a749-9d3396801906"
       ],
-      "edhrec_rank": 4700,
+      "edhrec_rank": 4833,
       "properties": [],
       "prices": {
-        "usd": "4.51"
+        "usd": "4.82"
       }
     },
     {
@@ -45823,7 +45856,7 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 1658,
+      "edhrec_rank": 1681,
       "properties": [],
       "prices": {
         "usd": "0.40"
@@ -45865,10 +45898,10 @@
       "artist_ids": [
         "1631a2ad-bf03-4ab9-b86c-60da982d58a1"
       ],
-      "edhrec_rank": 17013,
+      "edhrec_rank": 17302,
       "properties": [],
       "prices": {
-        "usd": "3.78"
+        "usd": "3.82"
       }
     },
     {
@@ -45913,10 +45946,10 @@
       "artist_ids": [
         "c09ede88-a1b5-4a18-9895-dc8a965d28a5"
       ],
-      "edhrec_rank": 11112,
+      "edhrec_rank": 11328,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.30"
       }
     },
     {
@@ -45954,10 +45987,10 @@
       "artist_ids": [
         "d7f03c52-e573-4082-9937-6c039b11ca70"
       ],
-      "edhrec_rank": 10171,
+      "edhrec_rank": 10077,
       "properties": [],
       "prices": {
-        "usd": "8.86"
+        "usd": "8.78"
       }
     },
     {
@@ -45999,10 +46032,10 @@
       "artist_ids": [
         "0fbd4798-76eb-46d5-a5d4-1e3a25870e34"
       ],
-      "edhrec_rank": 148,
+      "edhrec_rank": 149,
       "properties": [],
       "prices": {
-        "usd": "13.39"
+        "usd": "16.06"
       }
     },
     {
@@ -46044,10 +46077,10 @@
       "artist_ids": [
         "85908891-3cc7-42b0-9b54-27ed0fe89c53"
       ],
-      "edhrec_rank": 6642,
+      "edhrec_rank": 6882,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.11"
       }
     },
     {
@@ -46088,7 +46121,7 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 1052,
+      "edhrec_rank": 1075,
       "properties": [],
       "prices": {
         "usd": "0.09"
@@ -46133,10 +46166,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 7746,
+      "edhrec_rank": 7841,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.08"
       }
     },
     {
@@ -46178,10 +46211,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 22724,
+      "edhrec_rank": 22995,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.20"
       }
     },
     {
@@ -46224,10 +46257,10 @@
       "artist_ids": [
         "a5048cc7-438a-4378-98e4-da99b78e1db0"
       ],
-      "edhrec_rank": 1883,
+      "edhrec_rank": 1881,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.26"
       }
     },
     {
@@ -46268,10 +46301,10 @@
       "artist_ids": [
         "4441fe52-9e41-40c1-9b74-8510426279ab"
       ],
-      "edhrec_rank": 929,
+      "edhrec_rank": 964,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.31"
       }
     },
     {
@@ -46312,10 +46345,10 @@
       "artist_ids": [
         "81995d11-da98-4f8b-89bd-b88ca2ddb06b"
       ],
-      "edhrec_rank": 7776,
+      "edhrec_rank": 7906,
       "properties": [],
       "prices": {
-        "usd": "0.07"
+        "usd": "0.08"
       }
     },
     {
@@ -46371,10 +46404,10 @@
       "artist_ids": [
         "3593dd7e-c547-4a32-81cd-7da725f60118"
       ],
-      "edhrec_rank": 499,
+      "edhrec_rank": 502,
       "properties": [],
       "prices": {
-        "usd": "1.44"
+        "usd": "1.54"
       }
     },
     {
@@ -46414,10 +46447,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 1547,
+      "edhrec_rank": 1553,
       "properties": [],
       "prices": {
-        "usd": "1.35"
+        "usd": "1.54"
       }
     },
     {
@@ -46456,10 +46489,10 @@
       "artist_ids": [
         "f009de11-3c8d-4663-b996-ca0c3e997fad"
       ],
-      "edhrec_rank": 5528,
+      "edhrec_rank": 5612,
       "properties": [],
       "prices": {
-        "usd": "3.86"
+        "usd": "4.35"
       }
     },
     {
@@ -46499,10 +46532,10 @@
       "artist_ids": [
         "f0c43e1b-1853-4abc-8a1b-d7dda6c1d592"
       ],
-      "edhrec_rank": 7514,
+      "edhrec_rank": 7500,
       "properties": [],
       "prices": {
-        "usd": "0.45"
+        "usd": "0.47"
       }
     },
     {
@@ -46544,10 +46577,10 @@
       "artist_ids": [
         "561ebf9e-8d93-4b57-8156-8826d0c19601"
       ],
-      "edhrec_rank": 5188,
+      "edhrec_rank": 4919,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.19"
       }
     },
     {
@@ -46586,10 +46619,10 @@
       "artist_ids": [
         "17e629f2-3465-44cc-82f6-4e2386341bd7"
       ],
-      "edhrec_rank": 4351,
+      "edhrec_rank": 4506,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.34"
       }
     },
     {
@@ -46631,10 +46664,10 @@
       "artist_ids": [
         "262c8e55-4efc-467b-a042-6f734b9d2e01"
       ],
-      "edhrec_rank": 18817,
+      "edhrec_rank": 19140,
       "properties": [],
       "prices": {
-        "usd": "0.50"
+        "usd": "0.51"
       }
     },
     {
@@ -46677,10 +46710,10 @@
       "artist_ids": [
         "54366fc1-c5b1-4faa-a7a5-de2abc119de1"
       ],
-      "edhrec_rank": 9797,
+      "edhrec_rank": 10009,
       "properties": [],
       "prices": {
-        "usd": "1.19"
+        "usd": "1.78"
       }
     },
     {
@@ -46737,7 +46770,7 @@
       "artist_ids": [
         "c011318e-8503-48c1-a990-46e50aff48a0"
       ],
-      "edhrec_rank": 367,
+      "edhrec_rank": 363,
       "properties": [],
       "prices": {
         "usd": null
@@ -46781,10 +46814,10 @@
       "artist_ids": [
         "c011318e-8503-48c1-a990-46e50aff48a0"
       ],
-      "edhrec_rank": 371,
+      "edhrec_rank": 368,
       "properties": [],
       "prices": {
-        "usd": null
+        "usd": "3000.00"
       }
     },
     {
@@ -46811,9 +46844,12 @@
         "B",
         "G"
       ],
-      "edhrec_rank": 18911,
+      "edhrec_rank": 6099,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "7.88"
+      }
     },
     {
       "object": "card",
@@ -46839,9 +46875,12 @@
         "B",
         "W"
       ],
-      "edhrec_rank": 17727,
+      "edhrec_rank": 6329,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "5.84"
+      }
     },
     {
       "object": "card",
@@ -46867,9 +46906,12 @@
         "R",
         "U"
       ],
-      "edhrec_rank": 19180,
+      "edhrec_rank": 6856,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "5.63"
+      }
     },
     {
       "object": "card",
@@ -46895,9 +46937,12 @@
         "R",
         "W"
       ],
-      "edhrec_rank": 20124,
+      "edhrec_rank": 7473,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "5.23"
+      }
     },
     {
       "object": "card",
@@ -46923,9 +46968,12 @@
         "G",
         "U"
       ],
-      "edhrec_rank": 19888,
+      "edhrec_rank": 7229,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "6.48"
+      }
     },
     {
       "object": "card",
@@ -46963,10 +47011,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 17742,
+      "edhrec_rank": 17894,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.10"
       }
     },
     {
@@ -47032,10 +47080,10 @@
       "artist_ids": [
         "d20672ca-0555-4238-a984-fd171d36b247"
       ],
-      "edhrec_rank": 2231,
+      "edhrec_rank": 2260,
       "properties": [],
       "prices": {
-        "usd": "2.35"
+        "usd": "2.77"
       }
     },
     {
@@ -47063,11 +47111,11 @@
         "U",
         "W"
       ],
-      "edhrec_rank": 8280,
+      "edhrec_rank": 6958,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.30"
       }
     },
     {
@@ -47110,10 +47158,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 424,
+      "edhrec_rank": 383,
       "properties": [],
       "prices": {
-        "usd": "5.08"
+        "usd": "5.19"
       }
     },
     {
@@ -47156,10 +47204,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 1701,
+      "edhrec_rank": 1702,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.26"
       }
     },
     {
@@ -47196,10 +47244,10 @@
       "artist_ids": [
         "93bec3c0-0260-4d31-8064-5d01efb4153f"
       ],
-      "edhrec_rank": 1014,
+      "edhrec_rank": 1060,
       "properties": [],
       "prices": {
-        "usd": "2.87"
+        "usd": "2.90"
       }
     },
     {
@@ -47238,10 +47286,10 @@
       "artist_ids": [
         "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
       ],
-      "edhrec_rank": 2898,
+      "edhrec_rank": 2831,
       "properties": [],
       "prices": {
-        "usd": "13.88"
+        "usd": "14.44"
       }
     },
     {
@@ -47310,10 +47358,10 @@
       "artist_ids": [
         "a5f8354a-8b51-4e59-96b2-0e3aeae4fa1d"
       ],
-      "edhrec_rank": 14040,
+      "edhrec_rank": 14183,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.21"
       }
     },
     {
@@ -47342,9 +47390,12 @@
         "B",
         "W"
       ],
-      "edhrec_rank": 21109,
+      "edhrec_rank": 10612,
       "is_basic": false,
-      "properties": []
+      "properties": [],
+      "prices": {
+        "usd": "0.63"
+      }
     },
     {
       "object": "card",
@@ -47385,10 +47436,10 @@
       "artist_ids": [
         "334dd388-1e26-4181-8eca-f9c097e29c5e"
       ],
-      "edhrec_rank": 2740,
+      "edhrec_rank": 2726,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.22"
       }
     },
     {
@@ -47430,10 +47481,10 @@
       "artist_ids": [
         "ad53afd6-d00f-4bc8-98ec-deab3f6aec50"
       ],
-      "edhrec_rank": 236,
+      "edhrec_rank": 243,
       "properties": [],
       "prices": {
-        "usd": "1.25"
+        "usd": "0.48"
       }
     },
     {
@@ -47476,10 +47527,10 @@
       "artist_ids": [
         "f8e7f8d6-6dde-4059-973c-30f1fd1bbe4e"
       ],
-      "edhrec_rank": 432,
+      "edhrec_rank": 434,
       "properties": [],
       "prices": {
-        "usd": "19.72"
+        "usd": "17.82"
       }
     },
     {
@@ -47516,10 +47567,10 @@
       "artist_ids": [
         "b5f1bd34-abee-40c9-99f7-a6ee089fb30b"
       ],
-      "edhrec_rank": 6397,
+      "edhrec_rank": 6592,
       "properties": [],
       "prices": {
-        "usd": "0.42"
+        "usd": "0.50"
       }
     },
     {
@@ -47562,10 +47613,10 @@
       "artist_ids": [
         "8df4596a-1d88-4b6a-9ce8-5c8089c3946c"
       ],
-      "edhrec_rank": 473,
+      "edhrec_rank": 470,
       "properties": [],
       "prices": {
-        "usd": "14.30"
+        "usd": "16.51"
       }
     },
     {
@@ -47610,7 +47661,7 @@
       "edhrec_rank": 152,
       "properties": [],
       "prices": {
-        "usd": "33.83"
+        "usd": "33.89"
       }
     },
     {
@@ -47651,7 +47702,7 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 299,
+      "edhrec_rank": 300,
       "properties": [],
       "prices": {
         "usd": null
@@ -47696,10 +47747,10 @@
       "artist_ids": [
         "f8e7f8d6-6dde-4059-973c-30f1fd1bbe4e"
       ],
-      "edhrec_rank": 179,
+      "edhrec_rank": 175,
       "properties": [],
       "prices": {
-        "usd": "9.08"
+        "usd": "7.07"
       }
     },
     {
@@ -47741,10 +47792,10 @@
       "artist_ids": [
         "bd8dcf6f-4ab3-4854-bfb0-f2e21610fc16"
       ],
-      "edhrec_rank": 16373,
+      "edhrec_rank": 16575,
       "properties": [],
       "prices": {
-        "usd": "35.12"
+        "usd": "37.61"
       }
     },
     {
@@ -47778,10 +47829,10 @@
       "artist_ids": [
         "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
       ],
-      "edhrec_rank": 25227,
+      "edhrec_rank": 25314,
       "properties": [],
       "prices": {
-        "usd": "5.37"
+        "usd": "5.63"
       }
     },
     {
@@ -47820,10 +47871,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 2958,
+      "edhrec_rank": 2956,
       "properties": [],
       "prices": {
-        "usd": "6.75"
+        "usd": "6.65"
       }
     },
     {
@@ -47852,11 +47903,11 @@
         "U",
         "W"
       ],
-      "edhrec_rank": 10914,
+      "edhrec_rank": 10452,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.18"
       }
     },
     {
@@ -47899,7 +47950,7 @@
       "artist_ids": [
         "ad4caca0-8d89-44ce-a1a6-d5ca905bd6fb"
       ],
-      "edhrec_rank": 7475,
+      "edhrec_rank": 7536,
       "properties": [],
       "prices": {
         "usd": "0.10"
@@ -47940,10 +47991,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 20459,
+      "edhrec_rank": 20606,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.22"
       }
     },
     {
@@ -47981,10 +48032,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 9731,
+      "edhrec_rank": 9899,
       "properties": [],
       "prices": {
-        "usd": "6.22"
+        "usd": "5.73"
       }
     },
     {
@@ -48013,11 +48064,11 @@
         "U",
         "W"
       ],
-      "edhrec_rank": 6154,
+      "edhrec_rank": 5688,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.63"
+        "usd": "0.60"
       }
     },
     {
@@ -48057,10 +48108,10 @@
       "artist_ids": [
         "c99a114b-c679-47df-a6e9-4f9d3ad5b114"
       ],
-      "edhrec_rank": 8930,
+      "edhrec_rank": 9043,
       "properties": [],
       "prices": {
-        "usd": "17.62"
+        "usd": "18.22"
       }
     },
     {
@@ -48102,10 +48153,10 @@
       "artist_ids": [
         "1952c90b-a5a7-4328-9f7c-e11064f59daf"
       ],
-      "edhrec_rank": 10769,
+      "edhrec_rank": 10900,
       "properties": [],
       "prices": {
-        "usd": "0.42"
+        "usd": "0.37"
       }
     },
     {
@@ -48143,10 +48194,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 71,
+      "edhrec_rank": 72,
       "properties": [],
       "prices": {
-        "usd": "53.81"
+        "usd": "57.76"
       }
     },
     {
@@ -48184,10 +48235,10 @@
       "artist_ids": [
         "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
       ],
-      "edhrec_rank": 466,
+      "edhrec_rank": 444,
       "properties": [],
       "prices": {
-        "usd": "1.43"
+        "usd": "0.84"
       }
     },
     {
@@ -48241,10 +48292,10 @@
       "artist_ids": [
         "9ee9a9cc-c09e-486f-918b-69f80cbc4188"
       ],
-      "edhrec_rank": 4499,
+      "edhrec_rank": 4563,
       "properties": [],
       "prices": {
-        "usd": "0.50"
+        "usd": "0.54"
       }
     },
     {
@@ -48312,10 +48363,10 @@
       "artist_ids": [
         "634430a7-b5c3-4e4a-b2ac-164e084e47c9"
       ],
-      "edhrec_rank": 817,
+      "edhrec_rank": 834,
       "properties": [],
       "prices": {
-        "usd": "17.73"
+        "usd": "17.45"
       }
     },
     {
@@ -48383,10 +48434,10 @@
       "artist_ids": [
         "9ee9a9cc-c09e-486f-918b-69f80cbc4188"
       ],
-      "edhrec_rank": 822,
+      "edhrec_rank": 835,
       "properties": [],
       "prices": {
-        "usd": "4.80"
+        "usd": "4.96"
       }
     },
     {
@@ -48439,10 +48490,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 119,
+      "edhrec_rank": 121,
       "properties": [],
       "prices": {
-        "usd": "40.27"
+        "usd": "40.26"
       }
     },
     {
@@ -48510,10 +48561,10 @@
       "artist_ids": [
         "bfdeaf09-f915-4058-8e8b-bcac3bc43c33"
       ],
-      "edhrec_rank": 809,
+      "edhrec_rank": 821,
       "properties": [],
       "prices": {
-        "usd": "13.45"
+        "usd": "13.77"
       }
     },
     {
@@ -48553,10 +48604,10 @@
       "artist_ids": [
         "85908891-3cc7-42b0-9b54-27ed0fe89c53"
       ],
-      "edhrec_rank": 2418,
+      "edhrec_rank": 2415,
       "properties": [],
       "prices": {
-        "usd": "17.46"
+        "usd": "22.06"
       }
     },
     {
@@ -48596,10 +48647,10 @@
       "artist_ids": [
         "89023dad-e6c0-41e0-83fb-eb2bfbbdc3f2"
       ],
-      "edhrec_rank": 1841,
+      "edhrec_rank": 1679,
       "properties": [],
       "prices": {
-        "usd": "10.33"
+        "usd": "10.70"
       }
     },
     {
@@ -48666,10 +48717,10 @@
       "artist_ids": [
         "d281eab4-463a-4ba8-9039-8943737960a0"
       ],
-      "edhrec_rank": 520,
+      "edhrec_rank": 516,
       "properties": [],
       "prices": {
-        "usd": "15.17"
+        "usd": "15.61"
       }
     },
     {
@@ -48708,10 +48759,10 @@
       "artist_ids": [
         "aa7e89ed-d294-4633-9057-ce04dacfcfa4"
       ],
-      "edhrec_rank": 1393,
+      "edhrec_rank": 1380,
       "properties": [],
       "prices": {
-        "usd": "15.69"
+        "usd": "15.97"
       }
     },
     {
@@ -48755,10 +48806,10 @@
       "artist_ids": [
         "bc760b5e-6f98-4a17-9b12-5f4eccd12bb2"
       ],
-      "edhrec_rank": 1722,
+      "edhrec_rank": 1701,
       "properties": [],
       "prices": {
-        "usd": "0.79"
+        "usd": "0.95"
       }
     },
     {
@@ -48825,10 +48876,10 @@
       "artist_ids": [
         "55e6d846-2f73-4fba-9b88-441686bb8dcb"
       ],
-      "edhrec_rank": 6157,
+      "edhrec_rank": 6177,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.21"
       }
     },
     {
@@ -48870,10 +48921,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 167,
+      "edhrec_rank": 169,
       "properties": [],
       "prices": {
-        "usd": "14.71"
+        "usd": "16.45"
       }
     },
     {
@@ -48914,10 +48965,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 454,
+      "edhrec_rank": 450,
       "properties": [],
       "prices": {
-        "usd": "1.02"
+        "usd": "1.06"
       }
     },
     {
@@ -48957,10 +49008,10 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 605,
+      "edhrec_rank": 607,
       "properties": [],
       "prices": {
-        "usd": "5.17"
+        "usd": "4.46"
       }
     },
     {
@@ -49002,10 +49053,10 @@
       "artist_ids": [
         "5c783e76-8520-483c-96d1-10052f35202c"
       ],
-      "edhrec_rank": 25037,
+      "edhrec_rank": 25115,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.20"
       }
     },
     {
@@ -49047,10 +49098,10 @@
       "artist_ids": [
         "eae339a0-a8be-40b9-9878-55f7de9256f9"
       ],
-      "edhrec_rank": 5780,
+      "edhrec_rank": 5509,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.26"
       }
     },
     {
@@ -49091,10 +49142,10 @@
       "artist_ids": [
         "c99a114b-c679-47df-a6e9-4f9d3ad5b114"
       ],
-      "edhrec_rank": 28382,
+      "edhrec_rank": 28572,
       "properties": [],
       "prices": {
-        "usd": "1.23"
+        "usd": "1.22"
       }
     },
     {
@@ -49131,7 +49182,7 @@
       "edhrec_rank": 47,
       "properties": [],
       "prices": {
-        "usd": "27.92"
+        "usd": "32.51"
       }
     },
     {
@@ -49172,10 +49223,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 1345,
+      "edhrec_rank": 987,
       "properties": [],
       "prices": {
-        "usd": "1.82"
+        "usd": "0.75"
       }
     },
     {
@@ -49211,10 +49262,10 @@
         "1885e6cb-c827-4896-994e-3d0a027d602f",
         "44c3877f-8771-43dc-9e40-f4c765f59d2e"
       ],
-      "edhrec_rank": 906,
+      "edhrec_rank": 904,
       "properties": [],
       "prices": {
-        "usd": "5.56"
+        "usd": "5.44"
       }
     },
     {
@@ -49234,11 +49285,11 @@
       "oracle_text": "{T}, Sacrifice this land: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
       "color_identity": [],
       "keywords": [],
-      "edhrec_rank": 2035,
+      "edhrec_rank": 1781,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.17"
       }
     },
     {
@@ -49281,10 +49332,10 @@
       "artist_ids": [
         "f89f4b78-cefb-41f7-b7cb-4f4d28de0c4f"
       ],
-      "edhrec_rank": 548,
+      "edhrec_rank": 537,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.39"
       }
     },
     {
@@ -49326,10 +49377,10 @@
       "artist_ids": [
         "5157b931-ac23-49b6-a2c4-c4cf4bbc2118"
       ],
-      "edhrec_rank": 777,
+      "edhrec_rank": 729,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.38"
       }
     },
     {
@@ -49387,10 +49438,10 @@
       "artist_ids": [
         "30fead7c-da53-4c1b-b514-4be6e5ce487c"
       ],
-      "edhrec_rank": 7727,
+      "edhrec_rank": 7904,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.15"
       }
     },
     {
@@ -49433,10 +49484,10 @@
       "artist_ids": [
         "30fead7c-da53-4c1b-b514-4be6e5ce487c"
       ],
-      "edhrec_rank": 6875,
+      "edhrec_rank": 7010,
       "properties": [],
       "prices": {
-        "usd": "1.40"
+        "usd": "1.53"
       }
     },
     {
@@ -49479,10 +49530,10 @@
       "artist_ids": [
         "9c77c81a-3b3f-4e94-a834-327d01cd6b35"
       ],
-      "edhrec_rank": 4159,
+      "edhrec_rank": 4290,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.38"
       }
     },
     {
@@ -49525,10 +49576,10 @@
       "artist_ids": [
         "6dd06426-59fe-4b9c-aad5-6da8446a5c3d"
       ],
-      "edhrec_rank": 4160,
+      "edhrec_rank": 4305,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.41"
       }
     },
     {
@@ -49571,7 +49622,7 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 5924,
+      "edhrec_rank": 6081,
       "properties": [],
       "prices": {
         "usd": "0.89"
@@ -49617,7 +49668,7 @@
       "artist_ids": [
         "35906871-6c78-4ab2-9ed1-e6792c8efb74"
       ],
-      "edhrec_rank": 5571,
+      "edhrec_rank": 5717,
       "properties": [],
       "prices": {
         "usd": "0.40"
@@ -49675,10 +49726,10 @@
       "artist_ids": [
         "adad79bf-cd52-456a-b170-740ed8bff0fc"
       ],
-      "edhrec_rank": 2442,
+      "edhrec_rank": 2500,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.27"
       }
     },
     {
@@ -49720,10 +49771,10 @@
       "artist_ids": [
         "d20672ca-0555-4238-a984-fd171d36b247"
       ],
-      "edhrec_rank": 4631,
+      "edhrec_rank": 4825,
       "properties": [],
       "prices": {
-        "usd": "0.83"
+        "usd": "0.89"
       }
     },
     {
@@ -49764,7 +49815,7 @@
       "artist_ids": [
         "770b4e16-de76-49ed-949f-84e6d2e06d25"
       ],
-      "edhrec_rank": 351,
+      "edhrec_rank": 346,
       "properties": [],
       "prices": {
         "usd": null
@@ -49825,10 +49876,10 @@
       "artist_ids": [
         "7b1b0ce9-2c58-4321-a2a7-cdc94feae082"
       ],
-      "edhrec_rank": 2364,
+      "edhrec_rank": 2390,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.29"
       }
     },
     {
@@ -49868,10 +49919,10 @@
       "artist_ids": [
         "f366a0ee-a0cd-466d-ba6a-90058c7a31a6"
       ],
-      "edhrec_rank": 2774,
+      "edhrec_rank": 2796,
       "properties": [],
       "prices": {
-        "usd": "94.01"
+        "usd": "111.25"
       }
     },
     {
@@ -49912,10 +49963,10 @@
       "artist_ids": [
         "f28c54ff-bbe3-485d-81a4-b2cb49430a52"
       ],
-      "edhrec_rank": 7419,
+      "edhrec_rank": 7531,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.36"
       }
     },
     {
@@ -49957,10 +50008,10 @@
       "artist_ids": [
         "002c739e-aa1f-4c1d-921b-37cb2d1b1c5b"
       ],
-      "edhrec_rank": 13955,
+      "edhrec_rank": 13980,
       "properties": [],
       "prices": {
-        "usd": "1.59"
+        "usd": "1.76"
       }
     },
     {
@@ -49998,10 +50049,10 @@
       "artist_ids": [
         "1eced451-4da5-42bc-b49d-70c41246581f"
       ],
-      "edhrec_rank": 150,
+      "edhrec_rank": 148,
       "properties": [],
       "prices": {
-        "usd": "7.61"
+        "usd": "6.05"
       }
     },
     {
@@ -50039,10 +50090,10 @@
       "artist_ids": [
         "ed6f7e03-20ba-4c73-bdda-4a4928480721"
       ],
-      "edhrec_rank": 7575,
+      "edhrec_rank": 7729,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.33"
       }
     },
     {
@@ -50080,10 +50131,10 @@
       "artist_ids": [
         "0471a371-1bf8-49f2-8e76-cbe3a0bfa7e8"
       ],
-      "edhrec_rank": 1167,
+      "edhrec_rank": 1189,
       "properties": [],
       "prices": {
-        "usd": "50.21"
+        "usd": "55.16"
       }
     },
     {
@@ -50125,10 +50176,10 @@
       "artist_ids": [
         "70b1ba71-4ee1-4087-8a9e-ea919f20ebff"
       ],
-      "edhrec_rank": 1249,
+      "edhrec_rank": 1126,
       "properties": [],
       "prices": {
-        "usd": "9.00"
+        "usd": "11.57"
       }
     },
     {
@@ -50170,10 +50221,10 @@
       "artist_ids": [
         "85908891-3cc7-42b0-9b54-27ed0fe89c53"
       ],
-      "edhrec_rank": 6329,
+      "edhrec_rank": 6567,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.30"
       }
     },
     {
@@ -50215,10 +50266,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 1083,
+      "edhrec_rank": 1100,
       "properties": [],
       "prices": {
-        "usd": "1.66"
+        "usd": "1.81"
       }
     },
     {
@@ -50288,10 +50339,10 @@
       "artist_ids": [
         "a9ddb513-51c7-455c-ab8f-5b90aae9f75b"
       ],
-      "edhrec_rank": 1431,
+      "edhrec_rank": 1385,
       "properties": [],
       "prices": {
-        "usd": "0.65"
+        "usd": "0.40"
       }
     },
     {
@@ -50333,10 +50384,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 22559,
+      "edhrec_rank": 22978,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.21"
       }
     },
     {
@@ -50381,7 +50432,7 @@
       "edhrec_rank": 52,
       "properties": [],
       "prices": {
-        "usd": "17.79"
+        "usd": "18.17"
       }
     },
     {
@@ -50481,10 +50532,10 @@
       "artist_ids": [
         "9cb65d6f-8851-4d56-9add-9eefa274bd1b"
       ],
-      "edhrec_rank": 1419,
+      "edhrec_rank": 1427,
       "properties": [],
       "prices": {
-        "usd": "2.64"
+        "usd": "3.58"
       }
     },
     {
@@ -50512,11 +50563,11 @@
         "U",
         "W"
       ],
-      "edhrec_rank": 6429,
+      "edhrec_rank": 5981,
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.26"
       }
     },
     {
@@ -50571,10 +50622,10 @@
       "artist_ids": [
         "976cfe82-042e-4c2a-b762-2bc3e86cb6d0"
       ],
-      "edhrec_rank": 13235,
+      "edhrec_rank": 13116,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.09"
       }
     },
     {
@@ -50616,10 +50667,10 @@
       "artist_ids": [
         "fc021f3d-773a-4706-bbe7-f602324f511f"
       ],
-      "edhrec_rank": 1276,
+      "edhrec_rank": 1186,
       "properties": [],
       "prices": {
-        "usd": "8.86"
+        "usd": "8.19"
       }
     },
     {
@@ -50660,10 +50711,10 @@
       "artist_ids": [
         "0d8d6726-4051-445a-8374-a919aad98f38"
       ],
-      "edhrec_rank": 974,
+      "edhrec_rank": 992,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.25"
       }
     },
     {
@@ -50704,10 +50755,10 @@
       "artist_ids": [
         "256b61a2-b9af-4ff5-b485-47a61818f818"
       ],
-      "edhrec_rank": 642,
+      "edhrec_rank": 648,
       "properties": [],
       "prices": {
-        "usd": "1.18"
+        "usd": "1.08"
       }
     },
     {
@@ -50744,10 +50795,10 @@
       "artist_ids": [
         "798f3932-30e0-4420-aa3f-db4d613f89ca"
       ],
-      "edhrec_rank": 7763,
+      "edhrec_rank": 7758,
       "properties": [],
       "prices": {
-        "usd": "27.64"
+        "usd": "31.64"
       }
     },
     {
@@ -50784,7 +50835,7 @@
       "edhrec_rank": 46,
       "properties": [],
       "prices": {
-        "usd": "72.19"
+        "usd": "84.77"
       }
     },
     {
@@ -50826,10 +50877,10 @@
       "artist_ids": [
         "6cb0dc0c-4362-4c21-b23a-b2d7e096aa4f"
       ],
-      "edhrec_rank": 5884,
+      "edhrec_rank": 5610,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.19"
       }
     },
     {
@@ -50867,10 +50918,10 @@
       "artist_ids": [
         "c4e0aa7c-a008-4d71-80ce-d5a1ca0b251b"
       ],
-      "edhrec_rank": 26329,
+      "edhrec_rank": 26653,
       "properties": [],
       "prices": {
-        "usd": "0.46"
+        "usd": "0.42"
       }
     },
     {
@@ -50909,10 +50960,10 @@
       "artist_ids": [
         "f009de11-3c8d-4663-b996-ca0c3e997fad"
       ],
-      "edhrec_rank": 2426,
+      "edhrec_rank": 2444,
       "properties": [],
       "prices": {
-        "usd": "8.85"
+        "usd": "10.44"
       }
     },
     {
@@ -50981,10 +51032,10 @@
       "artist_ids": [
         "70c4c8c7-61a8-44e7-8fb1-161b7f943e7e"
       ],
-      "edhrec_rank": 342,
+      "edhrec_rank": 323,
       "properties": [],
       "prices": {
-        "usd": "2.85"
+        "usd": "3.11"
       }
     },
     {
@@ -51022,10 +51073,10 @@
       "artist_ids": [
         "aff176e8-1d15-432e-ad1d-207a474decba"
       ],
-      "edhrec_rank": 1096,
+      "edhrec_rank": 1086,
       "properties": [],
       "prices": {
-        "usd": "12.38"
+        "usd": "12.97"
       }
     },
     {
@@ -51064,10 +51115,10 @@
       "artist_ids": [
         "44c3877f-8771-43dc-9e40-f4c765f59d2e"
       ],
-      "edhrec_rank": 865,
+      "edhrec_rank": 868,
       "properties": [],
       "prices": {
-        "usd": "0.87"
+        "usd": "0.88"
       }
     },
     {
@@ -51112,10 +51163,10 @@
       "artist_ids": [
         "bb677b1a-ce51-4888-83d6-5a94de461ff9"
       ],
-      "edhrec_rank": 7732,
+      "edhrec_rank": 6707,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.27"
       }
     },
     {
@@ -51160,10 +51211,10 @@
       "artist_ids": [
         "3130411f-ddd5-4cab-a2f4-0a9c3b95a26e"
       ],
-      "edhrec_rank": 26103,
+      "edhrec_rank": 26331,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.30"
       }
     },
     {
@@ -51206,10 +51257,10 @@
       "artist_ids": [
         "21e10012-06ae-44f2-b38d-3824dd2e73d4"
       ],
-      "edhrec_rank": 1999,
+      "edhrec_rank": 2018,
       "properties": [],
       "prices": {
-        "usd": "16.23"
+        "usd": "16.64"
       }
     },
     {
@@ -51246,7 +51297,7 @@
       "edhrec_rank": 48,
       "properties": [],
       "prices": {
-        "usd": "92.40"
+        "usd": "108.94"
       }
     },
     {
@@ -51288,10 +51339,10 @@
       "artist_ids": [
         "0cd53596-1525-42af-83ae-ff02401311ee"
       ],
-      "edhrec_rank": 1663,
+      "edhrec_rank": 1721,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.27"
       }
     },
     {
@@ -51333,7 +51384,7 @@
       "artist_ids": [
         "21ed6499-c4d3-4965-ab02-6c7228275bec"
       ],
-      "edhrec_rank": 122,
+      "edhrec_rank": 114,
       "properties": [],
       "prices": {
         "usd": "1.23"
@@ -51378,10 +51429,10 @@
       "artist_ids": [
         "b11e6b3a-f4ca-4cf1-8fd7-475696de5f5c"
       ],
-      "edhrec_rank": 2695,
+      "edhrec_rank": 2852,
       "properties": [],
       "prices": {
-        "usd": "0.57"
+        "usd": "0.59"
       }
     },
     {
@@ -51423,10 +51474,10 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 4915,
+      "edhrec_rank": 5058,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.12"
       }
     },
     {
@@ -51473,10 +51524,10 @@
       "artist_ids": [
         "1a7be0a2-d8ac-45c7-b0a0-eb0886f47b5f"
       ],
-      "edhrec_rank": 453,
+      "edhrec_rank": 468,
       "properties": [],
       "prices": {
-        "usd": "14.67"
+        "usd": "13.77"
       }
     },
     {
@@ -51521,7 +51572,7 @@
       "edhrec_rank": 134,
       "properties": [],
       "prices": {
-        "usd": "34.07"
+        "usd": "32.80"
       }
     },
     {
@@ -51561,10 +51612,10 @@
       "artist_ids": [
         "a9ddb513-51c7-455c-ab8f-5b90aae9f75b"
       ],
-      "edhrec_rank": 3752,
+      "edhrec_rank": 3767,
       "properties": [],
       "prices": {
-        "usd": "69.37"
+        "usd": "74.99"
       }
     },
     {
@@ -51602,10 +51653,10 @@
       "artist_ids": [
         "e31f5891-08f7-4e5a-bac9-8b4570b8c1ab"
       ],
-      "edhrec_rank": 76,
+      "edhrec_rank": 75,
       "properties": [],
       "prices": {
-        "usd": "14.35"
+        "usd": "14.71"
       }
     },
     {
@@ -51651,10 +51702,10 @@
       "artist_ids": [
         "0d8d6726-4051-445a-8374-a919aad98f38"
       ],
-      "edhrec_rank": 390,
+      "edhrec_rank": 402,
       "properties": [],
       "prices": {
-        "usd": "28.76"
+        "usd": "25.64"
       }
     },
     {
@@ -51730,10 +51781,10 @@
       "artist_ids": [
         "39cb50cf-0223-43c7-bd96-afb5f05c7e43"
       ],
-      "edhrec_rank": 4343,
+      "edhrec_rank": 4109,
       "properties": [],
       "prices": {
-        "usd": "0.60"
+        "usd": "0.79"
       }
     },
     {
@@ -51773,10 +51824,10 @@
       "artist_ids": [
         "2d753f61-5f5b-468e-97ea-8e0fdd347340"
       ],
-      "edhrec_rank": 2575,
+      "edhrec_rank": 2594,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.39"
       }
     },
     {
@@ -51823,10 +51874,10 @@
       "artist_ids": [
         "92dfef2a-d0fa-42fd-bdd6-bc4c9286cb56"
       ],
-      "edhrec_rank": 502,
+      "edhrec_rank": 510,
       "properties": [],
       "prices": {
-        "usd": "12.39"
+        "usd": "10.69"
       }
     },
     {
@@ -51882,10 +51933,10 @@
       "artist_ids": [
         "21ed6499-c4d3-4965-ab02-6c7228275bec"
       ],
-      "edhrec_rank": 7159,
+      "edhrec_rank": 7345,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.34"
       }
     },
     {
@@ -51952,10 +52003,10 @@
       "artist_ids": [
         "2c3d2473-ff5d-4309-8194-e0b2def2ab65"
       ],
-      "edhrec_rank": 9557,
+      "edhrec_rank": 9513,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.15"
       }
     }
   ]

--- a/js/populator.js
+++ b/js/populator.js
@@ -450,19 +450,19 @@ const updateMobileColorFilters = () => {
 // Check if the data is already stored in localStorage
 const storedData = localStorage.getItem('landsData');
 const storedVersion = localStorage.getItem('landsDataVersion');
-const currentVersion = '10'; // Replace with the current version of the JSON data
+const currentVersion = '10.01'; // [VERSION]
 
 if (!storedVersion) {
     console.log('No data found.');
 }
-else if (storedData && storedVersion !== currentVersion) {
-    console.log('Current data version: ' + storedVersion);
+else if (storedVersion !== currentVersion) {
+    console.log('Stored data version: ' + storedVersion + '. Newest version is: ' + currentVersion);
 }
 
 if (storedData && storedVersion === currentVersion) {
   // If the data is already present in localStorage and has the same version, parse and assign it to the data variable
   data = JSON.parse(storedData);
-  console.log("Current data version: " + currentVersion + ".");
+  console.log("Using cached data version: " + currentVersion + ".");
   // Retrieve selectedCards from localStorage
   const storedSelectedCards = localStorage.getItem('selectedCards');
   selectedCards = storedSelectedCards ? JSON.parse(storedSelectedCards) : [];
@@ -477,11 +477,11 @@ if (storedData && storedVersion === currentVersion) {
     .done(function(responseData) {
       // Assign the data to the data variable
       data = responseData;
-      console.log("Newest data version: " + currentVersion + ".");
+      console.log("Fetched newest data version: " + data.version + ".");
       console.log("Loading new data...");
       // Store the fetched data and the version in localStorage
       localStorage.setItem('landsData', JSON.stringify(data));
-      localStorage.setItem('landsDataVersion', currentVersion);
+      localStorage.setItem('landsDataVersion', data.version);
 
       // Retrieve selectedCards from localStorage
       const storedSelectedCards = localStorage.getItem('selectedCards');

--- a/js/updater.js
+++ b/js/updater.js
@@ -1,6 +1,6 @@
 const SCRYFALL_API_URL =
   "https://api.scryfall.com/cards/search?q=type%3Aland+game%3Apaper+legal%3Acommander+-is%3Areprint";
-const LANDS_JSON_PATH = "../data/lands.json";
+const LANDS_JSON_PATH = "data/lands.json";
 
 const progressBar = document.getElementById("progress-bar");
 const progressText = document.getElementById("progress-text");
@@ -13,6 +13,7 @@ const includeUnreleasedCheckbox = document.getElementById("include-unreleased");
 
 let scryfallData = [];
 let originalLandsData = [];
+let originalJson = null;
 
 async function fetchScryfallData(url) {
   try {
@@ -56,8 +57,8 @@ async function main() {
 async function fetchOriginalLands() {
   try {
     const response = await fetch(LANDS_JSON_PATH);
-    const data = await response.json();
-    originalLandsData = data.data;
+    originalJson = await response.json();
+    originalLandsData = originalJson.data;
   } catch (error) {
     console.error("Error fetching original lands data:", error);
   }
@@ -65,11 +66,18 @@ async function fetchOriginalLands() {
 
 function compareAndDisplayNewCards() {
   const originalLandNames = new Set(originalLandsData.map((card) => card.name));
+  const today = new Date().toISOString().split('T')[0];
+
   let newCards = scryfallData.filter(
     (card) => !originalLandNames.has(card.name)
   );
 
   newCards = newCards.filter((card) => {
+    // Only released cards
+    if (card.released_at > today) {
+      return false;
+    }
+
     if (card.card_faces && card.card_faces.length > 0) {
       const frontFace = card.card_faces[0];
       if (frontFace.mana_cost && frontFace.oracle_text && frontFace.oracle_text.toLowerCase().includes("transform")) {
@@ -236,7 +244,8 @@ downloadButton.addEventListener("click", () => {
     }
   });
 
-  const newVersion = (parseFloat(originalLandsData.version) + 0.01).toFixed(2);
+  const currentVersion = originalJson ? originalJson.version : "0";
+  const newVersion = (parseFloat(currentVersion) + 0.01).toFixed(2);
   const updatedJson = {
     object: "list",
     total_cards: updatedLandsData.length,

--- a/scripts/update-lands.js
+++ b/scripts/update-lands.js
@@ -1,0 +1,151 @@
+const fs = require('fs');
+const path = require('path');
+
+const SCRYFALL_API_URL = "https://api.scryfall.com/cards/search?q=type%3Aland+game%3Apaper+legal%3Acommander+-is%3Areprint";
+const LANDS_JSON_PATH = path.join(__dirname, '../data/lands.json');
+const POPULATOR_JS_PATH = path.join(__dirname, '../js/populator.js');
+
+async function fetchScryfallData(url, allData = []) {
+    console.log(`Fetching ${url}...`);
+    const response = await fetch(url);
+    const data = await response.json();
+
+    allData.push(...data.data);
+
+    if (data.has_more) {
+        // Respect Scryfall API rate limiting
+        await new Promise(resolve => setTimeout(resolve, 100));
+        return fetchScryfallData(data.next_page, allData);
+    }
+    return allData;
+}
+
+async function main() {
+    try {
+        console.log("Starting update script...");
+
+        // 1. Fetch data from Scryfall
+        const scryfallData = await fetchScryfallData(SCRYFALL_API_URL);
+        console.log(`Fetched ${scryfallData.length} cards from Scryfall.`);
+
+        // 2. Read existing lands.json
+        const originalJson = JSON.parse(fs.readFileSync(LANDS_JSON_PATH, 'utf8'));
+        const originalLandsData = originalJson.data;
+        const originalLandNames = new Set(originalLandsData.map(card => card.name));
+        const today = new Date().toISOString().split('T')[0];
+
+        // 3. Find new released lands
+        let newLands = scryfallData.filter(card => {
+            // Not already in our list
+            if (originalLandNames.has(card.name)) return false;
+            // Only released cards
+            if (card.released_at > today) return false;
+            // Filter out transforming DFCs (logic from updater.js)
+            if (card.card_faces && card.card_faces.length > 0) {
+                const frontFace = card.card_faces[0];
+                if (frontFace.mana_cost && frontFace.oracle_text && frontFace.oracle_text.toLowerCase().includes("transform")) {
+                    return false;
+                }
+            }
+            return true;
+        }).map(card => ({
+            object: card.object,
+            id: card.id,
+            name: card.name,
+            released_at: card.released_at,
+            image_uris: card.image_uris,
+            type_line: card.type_line,
+            oracle_text: card.oracle_text,
+            color_identity: card.color_identity,
+            keywords: card.keywords,
+            produced_mana: card.produced_mana,
+            edhrec_rank: card.edhrec_rank,
+            prices: card.prices,
+            is_basic: false,
+            properties: [],
+        }));
+
+        console.log(`Found ${newLands.length} new lands.`);
+
+        // 4. Update existing lands (rank and price)
+        let updatedCount = 0;
+        originalLandsData.forEach(originalCard => {
+            const scryfallCard = scryfallData.find(card => card.name === originalCard.name);
+            if (scryfallCard && !originalCard.is_basic) {
+                let updated = false;
+                if (originalCard.edhrec_rank !== scryfallCard.edhrec_rank) {
+                    originalCard.edhrec_rank = scryfallCard.edhrec_rank;
+                    updated = true;
+                }
+                if (!originalCard.prices) originalCard.prices = {};
+                if (originalCard.prices.usd !== scryfallCard.prices.usd) {
+                    originalCard.prices.usd = scryfallCard.prices.usd;
+                    updated = true;
+                }
+                if (updated) updatedCount++;
+            }
+        });
+        console.log(`Updated ${updatedCount} existing lands.`);
+
+        if (newLands.length === 0 && updatedCount === 0) {
+            console.log("No changes detected. Skipping update.");
+            return;
+        }
+
+        // 5. Combine and sort
+        let updatedLandsData = [...originalLandsData, ...newLands];
+        const basicLandOrder = ["Plains", "Island", "Swamp", "Mountain", "Forest", "Wastes"];
+
+        updatedLandsData.forEach(card => {
+            if (basicLandOrder.includes(card.name)) {
+                if (!card.prices) card.prices = {};
+                card.prices.usd = "0.00"; // Changed to string to match common Scryfall format if needed, or 0
+            }
+        });
+
+        updatedLandsData.sort((a, b) => {
+            const aName = a.name;
+            const bName = b.name;
+            const aIsBasic = basicLandOrder.includes(aName);
+            const bIsBasic = basicLandOrder.includes(bName);
+
+            if (aIsBasic && bIsBasic) {
+                return basicLandOrder.indexOf(aName) - basicLandOrder.indexOf(bName);
+            } else if (aIsBasic) {
+                return -1;
+            } else if (bIsBasic) {
+                return 1;
+            } else {
+                return aName.localeCompare(bName);
+            }
+        });
+
+        // 6. Calculate new version
+        const currentVersion = originalJson.version || "0";
+        const newVersion = (parseFloat(currentVersion) + 0.01).toFixed(2);
+        console.log(`New version: ${newVersion}`);
+
+        const updatedJson = {
+            object: "list",
+            total_cards: updatedLandsData.length,
+            version: newVersion,
+            data: updatedLandsData,
+        };
+
+        // 7. Write updated lands.json
+        fs.writeFileSync(LANDS_JSON_PATH, JSON.stringify(updatedJson, null, 2));
+        console.log("Updated data/lands.json");
+
+        // 8. Update version in js/populator.js
+        let populatorJs = fs.readFileSync(POPULATOR_JS_PATH, 'utf8');
+        populatorJs = populatorJs.replace(/const currentVersion = '.*'; \/\/ \[VERSION\]/, `const currentVersion = '${newVersion}'; // [VERSION]`);
+        fs.writeFileSync(POPULATOR_JS_PATH, populatorJs);
+        console.log("Updated js/populator.js version.");
+
+    } catch (error) {
+        console.error("Error in update script:", error);
+        process.exit(1);
+    }
+}
+
+main();

--- a/server.log
+++ b/server.log
@@ -1,0 +1,18 @@
+Traceback (most recent call last):
+  File "<frozen runpy>", line 198, in _run_module_as_main
+  File "<frozen runpy>", line 88, in _run_code
+  File "/home/jules/.pyenv/versions/3.12.13/lib/python3.12/http/server.py", line 1329, in <module>
+    test(
+  File "/home/jules/.pyenv/versions/3.12.13/lib/python3.12/http/server.py", line 1276, in test
+    with ServerClass(addr, HandlerClass) as httpd:
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/jules/.pyenv/versions/3.12.13/lib/python3.12/socketserver.py", line 457, in __init__
+    self.server_bind()
+  File "/home/jules/.pyenv/versions/3.12.13/lib/python3.12/http/server.py", line 1323, in server_bind
+    return super().server_bind()
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/home/jules/.pyenv/versions/3.12.13/lib/python3.12/http/server.py", line 140, in server_bind
+    socketserver.TCPServer.server_bind(self)
+  File "/home/jules/.pyenv/versions/3.12.13/lib/python3.12/socketserver.py", line 478, in server_bind
+    self.socket.bind(self.server_address)
+OSError: [Errno 98] Address already in use


### PR DESCRIPTION
I have automated the land data update process and fixed the bugs you identified.

### Key Changes:
1.  **Bug Fixes:**
    *   Fixed `js/updater.js` to correctly locate `data/lands.json`, resolving the issue where all lands were seen as new.
    *   Fixed the "NaN version" bug by correcting how the version is parsed and incremented in both the manual updater and the new automation script.
2.  **Automation:**
    *   Created `scripts/update-lands.js`, a Node.js script that fetches data from Scryfall, filters for released cards, updates prices/ranks, and increments the version.
    *   Implemented a GitHub Action (`.github/workflows/update-lands.yml`) that runs this script weekly or on-demand.
3.  **Versioning System:**
    *   Synchronized the version between `data/lands.json` and `js/populator.js` using a `// [VERSION]` marker, allowing the frontend to intelligently decide when to refresh its local cache.

Only released cards are processed, and the system is designed to run entirely within GitHub Pages/Actions without requiring a backend server.

---
*PR created automatically by Jules for task [4071619492597963871](https://jules.google.com/task/4071619492597963871) started by @NirDine*