### PR TITLE
Add Price Filter and Multi-Currency Support

### DIFF
--- a/buffet.html
+++ b/buffet.html
@@ -329,6 +329,28 @@
                         </label>
                       </div>
                     <!-- End of sorting option -->
+
+                    <!-- Start of sorting option -->
+                      <div class="mana hidden" style="--hiddenCount: 8;">
+                        <input class="sorting" type="radio" id="sort-by-cheapest" name="sorting" value="cheapest" />
+                        <label class="sort-cheapest" for="sort-by-cheapest" title="Sort by price (cheapest first)">
+                          <span class="sort-label">
+                               Price (Cheapest)
+                          </span>
+                        </label>
+                      </div>
+                    <!-- End of sorting option -->
+
+                    <!-- Start of sorting option -->
+                      <div class="mana hidden" style="--hiddenCount: 8;">
+                        <input class="sorting" type="radio" id="sort-by-expensive" name="sorting" value="expensive" />
+                        <label class="sort-expensive" for="sort-by-expensive" title="Sort by price (most expensive first)">
+                          <span class="sort-label">
+                               Price (Most Expensive)
+                          </span>
+                        </label>
+                      </div>
+                    <!-- End of sorting option -->
                     
                     <!-- Start of sorting option -->
                       <div class="mana hidden" style="--hiddenCount: 8;">
@@ -374,6 +396,37 @@
                     </div>
                 </div>
               </div>
+              </div>
+              <div class="price-filter-toggle-container">
+                  <div class="mana hidden" style="--hiddenCount: 9.5;">
+                    <input class="price-filter-toggle" type="button" id="price-filter-toggle" name="price-filter-toggle" />
+                    <label class="price-filter-label" for="price-filter-toggle">Price: Any</label>
+                  </div>
+              </div>
+            </div>
+            <div id="priceFilters" class="price-filters hidden">
+              <div class="currency-picker">
+                  <div class="mana">
+                      <input type="radio" id="currency-usd" name="currency" value="usd" checked />
+                      <label for="currency-usd">USD</label>
+                  </div>
+                  <div class="mana">
+                      <input type="radio" id="currency-eur" name="currency" value="eur" />
+                      <label for="currency-eur">EUR</label>
+                  </div>
+                  <div class="mana">
+                      <input type="radio" id="currency-tix" name="currency" value="tix" />
+                      <label for="currency-tix">TIX</label>
+                  </div>
+              </div>
+              <div class="price-slider-container">
+                  <div id="price-slider"></div>
+              </div>
+              <div class="show-prices-container">
+                  <div class="mana">
+                    <input type="checkbox" id="show-prices" name="show-prices" />
+                    <label for="show-prices">Show Prices</label>
+                  </div>
               </div>
             </div>
             <div class="buffet-filters right">

--- a/css/structure.css
+++ b/css/structure.css
@@ -487,6 +487,45 @@ li:has(#navColors) {
     }
 }
 
+.price-filters {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5em;
+    padding: 1.5em;
+    background: #ffffff14;
+    border: 2px solid #0000006e;
+    border-radius: var(--bradius);
+    margin-bottom: 30px;
+}
+
+.currency-picker {
+    display: flex;
+    gap: 1em;
+    justify-content: center;
+}
+
+.price-slider-container {
+    padding-inline: 20px;
+}
+
+.show-prices-container {
+    display: flex;
+    justify-content: center;
+}
+
+.card-price {
+    position: absolute;
+    bottom: 10px;
+    left: 10px;
+    padding: 4px 8px;
+    background: rgba(0, 0, 0, 0.6);
+    color: var(--contrast);
+    border-radius: 4px;
+    font-size: 0.85em;
+    z-index: 5;
+    pointer-events: none;
+}
+
 .bottom .button {
   margin-top: 30px;
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -285,6 +285,32 @@ input[type="radio"]:checked + label,
 /*  PARENT COLORS */
 .buffet-filters:has(input[type="checkbox"]:checked:not(.parent):not(.property):not(.isAdded)) .filters  label.mobileColorTarget,
 
+.price-filters .mana:has(input:checked) label {
+  background: #4f1e37;
+  border-color: var(--accent);
+}
+
+.ui-slider-horizontal {
+    height: 10px;
+    background: #0000006e;
+    border: 1px solid #ffffff14;
+    border-radius: 5px;
+}
+
+.ui-slider-range {
+    background: var(--accent);
+}
+
+.ui-slider-handle {
+    width: 20px;
+    height: 20px;
+    background: var(--contrast);
+    border: 2px solid var(--accent);
+    border-radius: 50%;
+    cursor: pointer;
+    top: -6px;
+}
+
 /*  WHITE */
 .buffet-filters:has(#mana-w:checked) .section-dropdown label.mana-w,
 

--- a/data/lands.json
+++ b/data/lands.json
@@ -1,7 +1,7 @@
 {
   "object": "list",
   "total_cards": 1130,
-  "version": "10.03",
+  "version": "10.04",
   "data": [
     {
       "object": "card",
@@ -25,7 +25,9 @@
       "edhrec_rank": 1,
       "is_basic": true,
       "prices": {
-        "usd": "0.00"
+        "usd": "0.00",
+        "eur": "0.00",
+        "tix": "0.00"
       }
     },
     {
@@ -49,7 +51,9 @@
       "edhrec_rank": 2,
       "is_basic": true,
       "prices": {
-        "usd": "0.00"
+        "usd": "0.00",
+        "eur": "0.00",
+        "tix": "0.00"
       }
     },
     {
@@ -74,7 +78,9 @@
       "edhrec_rank": 3,
       "is_basic": true,
       "prices": {
-        "usd": "0.00"
+        "usd": "0.00",
+        "eur": "0.00",
+        "tix": "0.00"
       }
     },
     {
@@ -99,7 +105,9 @@
       "edhrec_rank": 4,
       "is_basic": true,
       "prices": {
-        "usd": "0.00"
+        "usd": "0.00",
+        "eur": "0.00",
+        "tix": "0.00"
       }
     },
     {
@@ -124,7 +132,9 @@
       "edhrec_rank": 5,
       "is_basic": true,
       "prices": {
-        "usd": "0.00"
+        "usd": "0.00",
+        "eur": "0.00",
+        "tix": "0.00"
       }
     },
     {
@@ -147,7 +157,9 @@
       "edhrec_rank": 6,
       "is_basic": true,
       "prices": {
-        "usd": "0.00"
+        "usd": "0.00",
+        "eur": "0.00",
+        "tix": "0.00"
       }
     },
     {
@@ -176,7 +188,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "7.42"
+        "usd": "7.42",
+        "eur": "7.28",
+        "tix": "0.26"
       }
     },
     {
@@ -221,7 +235,9 @@
       "edhrec_rank": 9302,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -267,7 +283,9 @@
       "edhrec_rank": 21778,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.13",
+        "tix": "0.09"
       }
     },
     {
@@ -312,7 +330,9 @@
       "edhrec_rank": 2720,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.20",
+        "tix": "0.03"
       }
     },
     {
@@ -358,7 +378,9 @@
       "edhrec_rank": 2094,
       "properties": [],
       "prices": {
-        "usd": "1.96"
+        "usd": "1.96",
+        "eur": "3.28",
+        "tix": "0.02"
       }
     },
     {
@@ -390,7 +412,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "3.67"
+        "usd": "3.67",
+        "eur": "6.18",
+        "tix": "14.99"
       }
     },
     {
@@ -434,7 +458,9 @@
       "edhrec_rank": 497,
       "properties": [],
       "prices": {
-        "usd": "8.33"
+        "usd": "8.33",
+        "eur": "5.76",
+        "tix": "0.02"
       }
     },
     {
@@ -475,7 +501,9 @@
       "edhrec_rank": 587,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.41",
+        "eur": "0.44",
+        "tix": "0.03"
       }
     },
     {
@@ -515,7 +543,9 @@
       "edhrec_rank": 2651,
       "properties": [],
       "prices": {
-        "usd": "0.82"
+        "usd": "0.82",
+        "eur": "0.99",
+        "tix": "2.92"
       }
     },
     {
@@ -558,7 +588,9 @@
       "edhrec_rank": 1985,
       "properties": [],
       "prices": {
-        "usd": "5.80"
+        "usd": "5.80",
+        "eur": "4.98",
+        "tix": "0.83"
       }
     },
     {
@@ -603,7 +635,9 @@
       "edhrec_rank": 159,
       "properties": [],
       "prices": {
-        "usd": "25.33"
+        "usd": "25.33",
+        "eur": "29.45",
+        "tix": null
       }
     },
     {
@@ -644,7 +678,9 @@
       "edhrec_rank": 1797,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.13",
+        "tix": "0.03"
       }
     },
     {
@@ -681,7 +717,9 @@
       "edhrec_rank": 21650,
       "properties": [],
       "prices": {
-        "usd": "11.80"
+        "usd": "11.80",
+        "eur": "8.71",
+        "tix": null
       }
     },
     {
@@ -743,7 +781,9 @@
       "edhrec_rank": 3214,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.35",
+        "tix": "0.03"
       }
     },
     {
@@ -813,7 +853,9 @@
       "edhrec_rank": 966,
       "properties": [],
       "prices": {
-        "usd": "28.88"
+        "usd": "28.88",
+        "eur": "23.03",
+        "tix": "1.79"
       }
     },
     {
@@ -842,7 +884,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "1.28"
+        "usd": "1.28",
+        "eur": "1.52",
+        "tix": "0.09"
       }
     },
     {
@@ -873,7 +917,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -917,7 +963,9 @@
       "edhrec_rank": 3586,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.24",
+        "tix": "0.03"
       }
     },
     {
@@ -991,7 +1039,9 @@
       "edhrec_rank": 12468,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.17",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -1035,7 +1085,9 @@
       "edhrec_rank": 1107,
       "properties": [],
       "prices": {
-        "usd": "4.14"
+        "usd": "4.14",
+        "eur": "1.66",
+        "tix": "0.02"
       }
     },
     {
@@ -1080,7 +1132,9 @@
       "edhrec_rank": 7824,
       "properties": [],
       "prices": {
-        "usd": "0.69"
+        "usd": "0.69",
+        "eur": "0.42",
+        "tix": "0.02"
       }
     },
     {
@@ -1125,7 +1179,9 @@
       "edhrec_rank": 4102,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.37",
+        "tix": "0.03"
       }
     },
     {
@@ -1185,7 +1241,9 @@
       "edhrec_rank": 2599,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.28",
+        "tix": "0.03"
       }
     },
     {
@@ -1233,7 +1291,9 @@
       "edhrec_rank": 26205,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.26",
+        "tix": null
       }
     },
     {
@@ -1278,7 +1338,9 @@
       "edhrec_rank": 11360,
       "properties": [],
       "prices": {
-        "usd": "0.62"
+        "usd": "0.62",
+        "eur": "0.36",
+        "tix": "0.02"
       }
     },
     {
@@ -1321,7 +1383,9 @@
       "edhrec_rank": 518,
       "properties": [],
       "prices": {
-        "usd": "2.44"
+        "usd": "2.44",
+        "eur": "1.39",
+        "tix": "0.84"
       }
     },
     {
@@ -1367,7 +1431,9 @@
       "edhrec_rank": 20371,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.21",
+        "eur": "0.15",
+        "tix": "0.05"
       }
     },
     {
@@ -1408,7 +1474,9 @@
       "edhrec_rank": 64,
       "properties": [],
       "prices": {
-        "usd": "127.09"
+        "usd": "127.09",
+        "eur": "99.00",
+        "tix": "29.47"
       }
     },
     {
@@ -1453,7 +1521,9 @@
       "edhrec_rank": 2727,
       "properties": [],
       "prices": {
-        "usd": "2.43"
+        "usd": "2.43",
+        "eur": "1.84",
+        "tix": "0.03"
       }
     },
     {
@@ -1494,7 +1564,9 @@
       "edhrec_rank": 3655,
       "properties": [],
       "prices": {
-        "usd": "3.49"
+        "usd": "3.49",
+        "eur": "1.24",
+        "tix": "0.02"
       }
     },
     {
@@ -1534,7 +1606,9 @@
       "edhrec_rank": 1093,
       "properties": [],
       "prices": {
-        "usd": "7.48"
+        "usd": "7.48",
+        "eur": "3.16",
+        "tix": "2.00"
       }
     },
     {
@@ -1581,7 +1655,9 @@
       "edhrec_rank": 340,
       "properties": [],
       "prices": {
-        "usd": "0.61"
+        "usd": "0.61",
+        "eur": "0.56",
+        "tix": "0.03"
       }
     },
     {
@@ -1639,7 +1715,9 @@
       "edhrec_rank": 2456,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.41",
+        "eur": "0.27",
+        "tix": "0.02"
       }
     },
     {
@@ -1684,7 +1762,9 @@
       "edhrec_rank": 17326,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.42",
+        "tix": "0.16"
       }
     },
     {
@@ -1728,7 +1808,9 @@
       "edhrec_rank": 9021,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.12",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -1770,7 +1852,9 @@
       "edhrec_rank": 936,
       "properties": [],
       "prices": {
-        "usd": "0.67"
+        "usd": "0.67",
+        "eur": "0.77",
+        "tix": "0.02"
       }
     },
     {
@@ -1815,7 +1899,9 @@
       "edhrec_rank": 13265,
       "properties": [],
       "prices": {
-        "usd": "1.89"
+        "usd": "1.89",
+        "eur": "0.57",
+        "tix": "0.03"
       }
     },
     {
@@ -1860,7 +1946,9 @@
       "edhrec_rank": 3600,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.36",
+        "tix": "0.03"
       }
     },
     {
@@ -1899,7 +1987,9 @@
       "edhrec_rank": 8836,
       "properties": [],
       "prices": {
-        "usd": "8.29"
+        "usd": "8.29",
+        "eur": "3.85",
+        "tix": null
       }
     },
     {
@@ -1941,7 +2031,9 @@
       "edhrec_rank": 388,
       "properties": [],
       "prices": {
-        "usd": "9.66"
+        "usd": "9.66",
+        "eur": "11.01",
+        "tix": "1.37"
       }
     },
     {
@@ -2015,7 +2107,9 @@
       "edhrec_rank": 3524,
       "properties": [],
       "prices": {
-        "usd": "1.66"
+        "usd": "1.66",
+        "eur": "0.97",
+        "tix": "0.02"
       }
     },
     {
@@ -2057,7 +2151,9 @@
       "edhrec_rank": 1454,
       "properties": [],
       "prices": {
-        "usd": "0.49"
+        "usd": "0.49",
+        "eur": "0.55",
+        "tix": "0.03"
       }
     },
     {
@@ -2094,7 +2190,9 @@
       "edhrec_rank": 55,
       "properties": [],
       "prices": {
-        "usd": "36.80"
+        "usd": "36.80",
+        "eur": "26.08",
+        "tix": "3.84"
       }
     },
     {
@@ -2139,7 +2237,9 @@
       "edhrec_rank": 191,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.31",
+        "tix": null
       }
     },
     {
@@ -2184,7 +2284,9 @@
       "edhrec_rank": 11040,
       "properties": [],
       "prices": {
-        "usd": "7.47"
+        "usd": "7.47",
+        "eur": "3.43",
+        "tix": "0.02"
       }
     },
     {
@@ -2244,7 +2346,9 @@
       "edhrec_rank": 4081,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.14",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -2287,7 +2391,9 @@
       "edhrec_rank": 3395,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.19",
+        "tix": "0.03"
       }
     },
     {
@@ -2335,7 +2441,9 @@
       "edhrec_rank": 26363,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.31",
+        "eur": "0.26",
+        "tix": null
       }
     },
     {
@@ -2380,7 +2488,9 @@
       "edhrec_rank": 436,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.23",
+        "tix": "0.03"
       }
     },
     {
@@ -2426,7 +2536,9 @@
       "edhrec_rank": 1994,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.12",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -2455,7 +2567,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "5.64"
+        "usd": "5.64",
+        "eur": "5.34",
+        "tix": "0.67"
       }
     },
     {
@@ -2492,7 +2606,9 @@
       "edhrec_rank": 6514,
       "properties": [],
       "prices": {
-        "usd": "1.60"
+        "usd": "1.60",
+        "eur": "1.24",
+        "tix": "0.10"
       }
     },
     {
@@ -2536,7 +2652,9 @@
       "edhrec_rank": 387,
       "properties": [],
       "prices": {
-        "usd": null
+        "usd": null,
+        "eur": "2584.72",
+        "tix": null
       }
     },
     {
@@ -2606,7 +2724,9 @@
       "edhrec_rank": 317,
       "properties": [],
       "prices": {
-        "usd": "7.44"
+        "usd": "7.44",
+        "eur": "4.83",
+        "tix": "0.03"
       }
     },
     {
@@ -2680,7 +2800,9 @@
       "edhrec_rank": 6734,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.27",
+        "tix": "0.02"
       }
     },
     {
@@ -2726,7 +2848,9 @@
       "edhrec_rank": 2395,
       "properties": [],
       "prices": {
-        "usd": "3.78"
+        "usd": "3.78",
+        "eur": "2.41",
+        "tix": "2.43"
       }
     },
     {
@@ -2769,7 +2893,9 @@
       "edhrec_rank": 17760,
       "properties": [],
       "prices": {
-        "usd": "4.31"
+        "usd": "4.31",
+        "eur": "2.38",
+        "tix": null
       }
     },
     {
@@ -2831,7 +2957,9 @@
       "edhrec_rank": 12557,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.25",
+        "tix": "0.02"
       }
     },
     {
@@ -2872,7 +3000,9 @@
       "edhrec_rank": 4739,
       "properties": [],
       "prices": {
-        "usd": "0.42"
+        "usd": "0.42",
+        "eur": "0.22",
+        "tix": "0.03"
       }
     },
     {
@@ -2933,7 +3063,9 @@
       "edhrec_rank": 1816,
       "properties": [],
       "prices": {
-        "usd": "1.66"
+        "usd": "1.66",
+        "eur": "0.82",
+        "tix": "0.02"
       }
     },
     {
@@ -2977,7 +3109,9 @@
       "edhrec_rank": 4822,
       "properties": [],
       "prices": {
-        "usd": "2.71"
+        "usd": "2.71",
+        "eur": "2.72",
+        "tix": "3.68"
       }
     },
     {
@@ -3047,7 +3181,9 @@
       "edhrec_rank": 1074,
       "properties": [],
       "prices": {
-        "usd": "4.39"
+        "usd": "4.39",
+        "eur": "4.64",
+        "tix": "0.07"
       }
     },
     {
@@ -3092,7 +3228,9 @@
       "edhrec_rank": 4868,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -3136,7 +3274,9 @@
       "edhrec_rank": 974,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.32",
+        "tix": "0.04"
       }
     },
     {
@@ -3198,7 +3338,9 @@
       "edhrec_rank": 10987,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.10",
+        "eur": "0.05",
+        "tix": "0.03"
       }
     },
     {
@@ -3239,7 +3381,9 @@
       "edhrec_rank": 2649,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.43",
+        "tix": "3.76"
       }
     },
     {
@@ -3284,7 +3428,9 @@
       "edhrec_rank": 123,
       "properties": [],
       "prices": {
-        "usd": "10.64"
+        "usd": "10.64",
+        "eur": "8.11",
+        "tix": "2.87"
       }
     },
     {
@@ -3328,7 +3474,9 @@
       "edhrec_rank": 431,
       "properties": [],
       "prices": {
-        "usd": null
+        "usd": null,
+        "eur": "3585.49",
+        "tix": null
       }
     },
     {
@@ -3365,7 +3513,9 @@
       "edhrec_rank": 10559,
       "properties": [],
       "prices": {
-        "usd": "1949.99"
+        "usd": "1949.99",
+        "eur": "2148.34",
+        "tix": null
       }
     },
     {
@@ -3435,7 +3585,9 @@
       "edhrec_rank": 9152,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.19",
+        "eur": "0.21",
+        "tix": "0.03"
       }
     },
     {
@@ -3466,7 +3618,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.35",
+        "tix": "1.36"
       }
     },
     {
@@ -3528,7 +3682,9 @@
       "edhrec_rank": 13847,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.21",
+        "tix": "0.02"
       }
     },
     {
@@ -3575,7 +3731,9 @@
       "edhrec_rank": 2376,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.41",
+        "eur": "0.47",
+        "tix": "0.68"
       }
     },
     {
@@ -3649,7 +3807,9 @@
       "edhrec_rank": 8561,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.13",
+        "eur": "0.18",
+        "tix": "0.03"
       }
     },
     {
@@ -3695,7 +3855,9 @@
       "edhrec_rank": 1067,
       "properties": [],
       "prices": {
-        "usd": "2.62"
+        "usd": "2.62",
+        "eur": "2.21",
+        "tix": "0.02"
       }
     },
     {
@@ -3735,7 +3897,9 @@
       "edhrec_rank": 1591,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.37",
+        "eur": "0.36",
+        "tix": "0.02"
       }
     },
     {
@@ -3777,7 +3941,9 @@
       "edhrec_rank": 5232,
       "properties": [],
       "prices": {
-        "usd": "1.63"
+        "usd": "1.63",
+        "eur": "1.31",
+        "tix": "1.35"
       }
     },
     {
@@ -3822,7 +3988,9 @@
       "edhrec_rank": 568,
       "properties": [],
       "prices": {
-        "usd": "8.75"
+        "usd": "8.75",
+        "eur": "8.13",
+        "tix": "0.09"
       }
     },
     {
@@ -3867,7 +4035,9 @@
       "edhrec_rank": 910,
       "properties": [],
       "prices": {
-        "usd": "10.81"
+        "usd": "10.81",
+        "eur": "9.55",
+        "tix": "0.09"
       }
     },
     {
@@ -3912,7 +4082,9 @@
       "edhrec_rank": 9484,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -3955,7 +4127,9 @@
       "edhrec_rank": 13198,
       "properties": [],
       "prices": {
-        "usd": "0.08"
+        "usd": "0.08",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -3998,7 +4172,9 @@
       "edhrec_rank": 12040,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.12",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -4041,7 +4217,9 @@
       "edhrec_rank": 16094,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.19",
+        "eur": "0.03",
+        "tix": "0.03"
       }
     },
     {
@@ -4084,7 +4262,9 @@
       "edhrec_rank": 7895,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.13",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -4126,7 +4306,9 @@
       "edhrec_rank": 823,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.26",
+        "tix": "0.03"
       }
     },
     {
@@ -4196,7 +4378,9 @@
       "edhrec_rank": 813,
       "properties": [],
       "prices": {
-        "usd": "5.51"
+        "usd": "5.51",
+        "eur": "5.22",
+        "tix": "0.06"
       }
     },
     {
@@ -4236,7 +4420,9 @@
       "edhrec_rank": 3009,
       "properties": [],
       "prices": {
-        "usd": "2.87"
+        "usd": "2.87",
+        "eur": "1.73",
+        "tix": "0.02"
       }
     },
     {
@@ -4277,7 +4463,9 @@
       "edhrec_rank": 15987,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.31",
+        "eur": "0.25",
+        "tix": "0.03"
       }
     },
     {
@@ -4322,7 +4510,9 @@
       "edhrec_rank": 69,
       "properties": [],
       "prices": {
-        "usd": "20.58"
+        "usd": "20.58",
+        "eur": "16.20",
+        "tix": "0.11"
       }
     },
     {
@@ -4366,7 +4556,9 @@
       "edhrec_rank": 893,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.19",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -4438,7 +4630,9 @@
       "edhrec_rank": 2620,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.31",
+        "eur": "0.19",
+        "tix": "0.03"
       }
     },
     {
@@ -4475,7 +4669,9 @@
       "edhrec_rank": 43,
       "properties": [],
       "prices": {
-        "usd": "77.96"
+        "usd": "77.96",
+        "eur": "50.57",
+        "tix": "7.98"
       }
     },
     {
@@ -4520,7 +4716,9 @@
       "edhrec_rank": 1496,
       "properties": [],
       "prices": {
-        "usd": "2.02"
+        "usd": "2.02",
+        "eur": "1.97",
+        "tix": "0.03"
       }
     },
     {
@@ -4564,7 +4762,9 @@
       "edhrec_rank": 1063,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.16",
+        "eur": "0.05",
+        "tix": "0.03"
       }
     },
     {
@@ -4610,7 +4810,9 @@
       "edhrec_rank": 21588,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.13",
+        "eur": "0.08",
+        "tix": "0.06"
       }
     },
     {
@@ -4682,7 +4884,9 @@
       "edhrec_rank": 666,
       "properties": [],
       "prices": {
-        "usd": "0.88"
+        "usd": "0.88",
+        "eur": "1.74",
+        "tix": "0.44"
       }
     },
     {
@@ -4713,7 +4917,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.26",
+        "eur": "0.14",
+        "tix": "0.04"
       }
     },
     {
@@ -4755,7 +4961,9 @@
       "edhrec_rank": 25,
       "properties": [],
       "prices": {
-        "usd": "2.02"
+        "usd": "2.02",
+        "eur": "1.28",
+        "tix": "0.97"
       }
     },
     {
@@ -4796,7 +5004,9 @@
       "edhrec_rank": 548,
       "properties": [],
       "prices": {
-        "usd": "0.72"
+        "usd": "0.72",
+        "eur": "0.68",
+        "tix": "0.02"
       }
     },
     {
@@ -4841,7 +5051,9 @@
       "edhrec_rank": 11608,
       "properties": [],
       "prices": {
-        "usd": "0.92"
+        "usd": "0.92",
+        "eur": "0.39",
+        "tix": "0.03"
       }
     },
     {
@@ -4886,7 +5098,9 @@
       "edhrec_rank": 461,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.29",
+        "tix": "0.03"
       }
     },
     {
@@ -4932,7 +5146,9 @@
       "edhrec_rank": 1739,
       "properties": [],
       "prices": {
-        "usd": "0.11"
+        "usd": "0.11",
+        "eur": "0.06",
+        "tix": "0.03"
       }
     },
     {
@@ -4976,7 +5192,9 @@
       "edhrec_rank": 77,
       "properties": [],
       "prices": {
-        "usd": "49.47"
+        "usd": "49.47",
+        "eur": "34.05",
+        "tix": "16.67"
       }
     },
     {
@@ -5016,7 +5234,9 @@
       "edhrec_rank": 2811,
       "properties": [],
       "prices": {
-        "usd": "17.22"
+        "usd": "17.22",
+        "eur": "6.33",
+        "tix": "0.02"
       }
     },
     {
@@ -5061,7 +5281,9 @@
       "edhrec_rank": 6831,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -5106,7 +5328,9 @@
       "edhrec_rank": 1661,
       "properties": [],
       "prices": {
-        "usd": "1.73"
+        "usd": "1.73",
+        "eur": "1.51",
+        "tix": "0.02"
       }
     },
     {
@@ -5148,7 +5372,9 @@
       "edhrec_rank": 15864,
       "properties": [],
       "prices": {
-        "usd": "1.39"
+        "usd": "1.39",
+        "eur": "0.99",
+        "tix": null
       }
     },
     {
@@ -5194,7 +5420,9 @@
       "edhrec_rank": 1618,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.31",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -5239,7 +5467,9 @@
       "edhrec_rank": 213,
       "properties": [],
       "prices": {
-        "usd": "17.85"
+        "usd": "17.85",
+        "eur": "14.26",
+        "tix": "2.03"
       }
     },
     {
@@ -5302,7 +5532,9 @@
       "edhrec_rank": 7242,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.19",
+        "eur": "0.13",
+        "tix": "0.03"
       }
     },
     {
@@ -5372,7 +5604,9 @@
       "edhrec_rank": 1132,
       "properties": [],
       "prices": {
-        "usd": "3.55"
+        "usd": "3.55",
+        "eur": "3.13",
+        "tix": "0.02"
       }
     },
     {
@@ -5417,7 +5651,9 @@
       "edhrec_rank": 63,
       "properties": [],
       "prices": {
-        "usd": "19.78"
+        "usd": "19.78",
+        "eur": "13.55",
+        "tix": "0.11"
       }
     },
     {
@@ -5476,7 +5712,9 @@
       "edhrec_rank": 10241,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -5548,7 +5786,9 @@
       "edhrec_rank": 703,
       "properties": [],
       "prices": {
-        "usd": "0.63"
+        "usd": "0.63",
+        "eur": "0.93",
+        "tix": "0.03"
       }
     },
     {
@@ -5618,7 +5858,9 @@
       "edhrec_rank": 747,
       "properties": [],
       "prices": {
-        "usd": "5.88"
+        "usd": "5.88",
+        "eur": "4.40",
+        "tix": "0.09"
       }
     },
     {
@@ -5663,7 +5905,9 @@
       "edhrec_rank": 3279,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.18",
+        "tix": "0.03"
       }
     },
     {
@@ -5702,7 +5946,9 @@
       "edhrec_rank": 1271,
       "properties": [],
       "prices": {
-        "usd": "0.92"
+        "usd": "0.92",
+        "eur": "0.69",
+        "tix": "0.03"
       }
     },
     {
@@ -5748,7 +5994,9 @@
       "edhrec_rank": 4909,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.22",
+        "tix": "1.19"
       }
     },
     {
@@ -5793,7 +6041,9 @@
       "edhrec_rank": 241,
       "properties": [],
       "prices": {
-        "usd": "18.74"
+        "usd": "18.74",
+        "eur": "17.24",
+        "tix": null
       }
     },
     {
@@ -5838,7 +6088,9 @@
       "edhrec_rank": 13733,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -5879,7 +6131,9 @@
       "edhrec_rank": 199,
       "properties": [],
       "prices": {
-        "usd": "0.56"
+        "usd": "0.56",
+        "eur": "0.50",
+        "tix": "0.04"
       }
     },
     {
@@ -5922,7 +6176,9 @@
       "edhrec_rank": 189,
       "properties": [],
       "prices": {
-        "usd": "31.67"
+        "usd": "31.67",
+        "eur": "18.37",
+        "tix": "0.39"
       }
     },
     {
@@ -5966,7 +6222,9 @@
       "edhrec_rank": 6392,
       "properties": [],
       "prices": {
-        "usd": "1.35"
+        "usd": "1.35",
+        "eur": "1.45",
+        "tix": "0.12"
       }
     },
     {
@@ -6010,7 +6268,9 @@
       "edhrec_rank": 969,
       "properties": [],
       "prices": {
-        "usd": "13.61"
+        "usd": "13.61",
+        "eur": "9.95",
+        "tix": "0.02"
       }
     },
     {
@@ -6049,7 +6309,9 @@
       "edhrec_rank": 948,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.39",
+        "eur": "0.29",
+        "tix": "0.03"
       }
     },
     {
@@ -6093,7 +6355,9 @@
       "edhrec_rank": 3593,
       "properties": [],
       "prices": {
-        "usd": "5.22"
+        "usd": "5.22",
+        "eur": "4.96",
+        "tix": "5.76"
       }
     },
     {
@@ -6138,7 +6402,9 @@
       "edhrec_rank": 11250,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.19",
+        "tix": "0.03"
       }
     },
     {
@@ -6183,7 +6449,9 @@
       "edhrec_rank": 19758,
       "properties": [],
       "prices": {
-        "usd": "1.43"
+        "usd": "1.43",
+        "eur": "1.18",
+        "tix": "0.05"
       }
     },
     {
@@ -6228,7 +6496,9 @@
       "edhrec_rank": 103,
       "properties": [],
       "prices": {
-        "usd": "0.45"
+        "usd": "0.45",
+        "eur": "0.55",
+        "tix": "0.02"
       }
     },
     {
@@ -6274,7 +6544,9 @@
       "edhrec_rank": 702,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.32",
+        "tix": "0.02"
       }
     },
     {
@@ -6322,7 +6594,9 @@
       "edhrec_rank": 4093,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.22",
+        "tix": "0.03"
       }
     },
     {
@@ -6367,7 +6641,9 @@
       "edhrec_rank": 5862,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.26",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -6413,7 +6689,9 @@
       "edhrec_rank": 312,
       "properties": [],
       "prices": {
-        "usd": "6.25"
+        "usd": "6.25",
+        "eur": "2.31",
+        "tix": "0.02"
       }
     },
     {
@@ -6461,7 +6739,9 @@
       "edhrec_rank": 1173,
       "properties": [],
       "prices": {
-        "usd": "1.90"
+        "usd": "1.90",
+        "eur": "0.99",
+        "tix": "0.02"
       }
     },
     {
@@ -6520,7 +6800,9 @@
       "edhrec_rank": 685,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.47",
+        "tix": "0.02"
       }
     },
     {
@@ -6563,7 +6845,9 @@
       "edhrec_rank": 1038,
       "properties": [],
       "prices": {
-        "usd": "0.48"
+        "usd": "0.48",
+        "eur": "0.27",
+        "tix": "0.02"
       }
     },
     {
@@ -6606,7 +6890,9 @@
       "edhrec_rank": 722,
       "properties": [],
       "prices": {
-        "usd": "7.54"
+        "usd": "7.54",
+        "eur": "4.93",
+        "tix": "0.02"
       }
     },
     {
@@ -6649,7 +6935,9 @@
       "edhrec_rank": 737,
       "properties": [],
       "prices": {
-        "usd": "3.47"
+        "usd": "3.47",
+        "eur": "3.16",
+        "tix": "0.33"
       }
     },
     {
@@ -6697,7 +6985,9 @@
       "edhrec_rank": 25523,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.31",
+        "tix": null
       }
     },
     {
@@ -6742,7 +7032,9 @@
       "edhrec_rank": 946,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.34",
+        "tix": "0.02"
       }
     },
     {
@@ -6779,7 +7071,9 @@
       "edhrec_rank": 20633,
       "properties": [],
       "prices": {
-        "usd": "31.12"
+        "usd": "31.12",
+        "eur": "13.74",
+        "tix": null
       }
     },
     {
@@ -6821,7 +7115,9 @@
       "edhrec_rank": 4859,
       "properties": [],
       "prices": {
-        "usd": "2.05"
+        "usd": "2.05",
+        "eur": "0.59",
+        "tix": "0.02"
       }
     },
     {
@@ -6866,7 +7162,9 @@
       "edhrec_rank": 9064,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -6908,7 +7206,9 @@
       "edhrec_rank": 7632,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.51",
+        "tix": "0.02"
       }
     },
     {
@@ -6953,7 +7253,9 @@
       "edhrec_rank": 112,
       "properties": [],
       "prices": {
-        "usd": "54.56"
+        "usd": "54.56",
+        "eur": "34.84",
+        "tix": "0.97"
       }
     },
     {
@@ -6994,7 +7296,9 @@
       "edhrec_rank": 14239,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.04",
+        "tix": "0.03"
       }
     },
     {
@@ -7039,7 +7343,9 @@
       "edhrec_rank": 125,
       "properties": [],
       "prices": {
-        "usd": "17.48"
+        "usd": "17.48",
+        "eur": "12.60",
+        "tix": "2.56"
       }
     },
     {
@@ -7083,7 +7389,9 @@
       "edhrec_rank": 5504,
       "properties": [],
       "prices": {
-        "usd": "0.97"
+        "usd": "0.97",
+        "eur": "0.56",
+        "tix": "0.02"
       }
     },
     {
@@ -7127,7 +7435,9 @@
       "edhrec_rank": 11831,
       "properties": [],
       "prices": {
-        "usd": "1.33"
+        "usd": "1.33",
+        "eur": "1.31",
+        "tix": "0.04"
       }
     },
     {
@@ -7171,7 +7481,9 @@
       "edhrec_rank": 842,
       "properties": [],
       "prices": {
-        "usd": "2.92"
+        "usd": "2.92",
+        "eur": "2.36",
+        "tix": "2.00"
       }
     },
     {
@@ -7200,7 +7512,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "9.27"
+        "usd": "9.27",
+        "eur": "4.59",
+        "tix": null
       }
     },
     {
@@ -7244,7 +7558,9 @@
       "edhrec_rank": 289,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.39",
+        "eur": "0.35",
+        "tix": "0.02"
       }
     },
     {
@@ -7289,7 +7605,9 @@
       "edhrec_rank": 6077,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.09",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -7334,7 +7652,9 @@
       "edhrec_rank": 85,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.42",
+        "tix": "0.03"
       }
     },
     {
@@ -7379,7 +7699,9 @@
       "edhrec_rank": 23090,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.25",
+        "tix": "0.04"
       }
     },
     {
@@ -7426,7 +7748,9 @@
       "edhrec_rank": 2828,
       "properties": [],
       "prices": {
-        "usd": "1.41"
+        "usd": "1.41",
+        "eur": "1.57",
+        "tix": "7.82"
       }
     },
     {
@@ -7470,7 +7794,9 @@
       "edhrec_rank": 98,
       "properties": [],
       "prices": {
-        "usd": "789.99"
+        "usd": "789.99",
+        "eur": "596.30",
+        "tix": null
       }
     },
     {
@@ -7510,7 +7836,9 @@
       "edhrec_rank": 16203,
       "properties": [],
       "prices": {
-        "usd": "63.38"
+        "usd": "63.38",
+        "eur": "55.79",
+        "tix": null
       }
     },
     {
@@ -7551,7 +7879,9 @@
       "edhrec_rank": 1248,
       "properties": [],
       "prices": {
-        "usd": "521.77"
+        "usd": "521.77",
+        "eur": "461.62",
+        "tix": "17.22"
       }
     },
     {
@@ -7621,7 +7951,9 @@
       "edhrec_rank": 752,
       "properties": [],
       "prices": {
-        "usd": "4.28"
+        "usd": "4.28",
+        "eur": "5.13",
+        "tix": "0.12"
       }
     },
     {
@@ -7668,7 +8000,9 @@
       "edhrec_rank": 2822,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.44",
+        "tix": "0.04"
       }
     },
     {
@@ -7713,7 +8047,9 @@
       "edhrec_rank": 84,
       "properties": [],
       "prices": {
-        "usd": "0.83"
+        "usd": "0.83",
+        "eur": "1.01",
+        "tix": "0.02"
       }
     },
     {
@@ -7755,7 +8091,9 @@
       "edhrec_rank": 5523,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.28",
+        "tix": "0.02"
       }
     },
     {
@@ -7800,7 +8138,9 @@
       "edhrec_rank": 22430,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -7841,7 +8181,9 @@
       "edhrec_rank": 5353,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.29",
+        "tix": "0.04"
       }
     },
     {
@@ -7874,7 +8216,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.57"
+        "usd": "0.57",
+        "eur": "0.57",
+        "tix": "3.96"
       }
     },
     {
@@ -7919,7 +8263,9 @@
       "edhrec_rank": 12058,
       "properties": [],
       "prices": {
-        "usd": "3.11"
+        "usd": "3.11",
+        "eur": "1.74",
+        "tix": "0.04"
       }
     },
     {
@@ -7960,7 +8306,9 @@
       "edhrec_rank": 182,
       "properties": [],
       "prices": {
-        "usd": "6.49"
+        "usd": "6.49",
+        "eur": "7.46",
+        "tix": null
       }
     },
     {
@@ -8003,7 +8351,9 @@
       "edhrec_rank": 3941,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -8048,7 +8398,9 @@
       "edhrec_rank": 2,
       "properties": [],
       "prices": {
-        "usd": "0.90"
+        "usd": "0.90",
+        "eur": "0.77",
+        "tix": "0.12"
       }
     },
     {
@@ -8094,7 +8446,9 @@
       "edhrec_rank": 644,
       "properties": [],
       "prices": {
-        "usd": "8.49"
+        "usd": "8.49",
+        "eur": "8.27",
+        "tix": "1.90"
       }
     },
     {
@@ -8139,7 +8493,9 @@
       "edhrec_rank": 1146,
       "properties": [],
       "prices": {
-        "usd": "1.16"
+        "usd": "1.16",
+        "eur": "1.04",
+        "tix": "0.07"
       }
     },
     {
@@ -8187,7 +8543,9 @@
       "edhrec_rank": 1960,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.18",
+        "tix": "0.03"
       }
     },
     {
@@ -8249,7 +8607,9 @@
       "edhrec_rank": 14759,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.20",
+        "tix": "0.02"
       }
     },
     {
@@ -8294,7 +8654,9 @@
       "edhrec_rank": 2128,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.63",
+        "tix": "0.03"
       }
     },
     {
@@ -8340,7 +8702,9 @@
       "edhrec_rank": 2164,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -8385,7 +8749,9 @@
       "edhrec_rank": 10050,
       "properties": [],
       "prices": {
-        "usd": "0.76"
+        "usd": "0.76",
+        "eur": "0.87",
+        "tix": "0.02"
       }
     },
     {
@@ -8426,7 +8792,9 @@
       "edhrec_rank": 14545,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.26",
+        "eur": "0.17",
+        "tix": "0.02"
       }
     },
     {
@@ -8473,7 +8841,9 @@
       "edhrec_rank": 1464,
       "properties": [],
       "prices": {
-        "usd": "1.68"
+        "usd": "1.68",
+        "eur": "1.56",
+        "tix": "0.02"
       }
     },
     {
@@ -8516,7 +8886,9 @@
       "edhrec_rank": 5700,
       "properties": [],
       "prices": {
-        "usd": "0.69"
+        "usd": "0.69",
+        "eur": "0.52",
+        "tix": "0.20"
       }
     },
     {
@@ -8560,7 +8932,9 @@
       "edhrec_rank": 3869,
       "properties": [],
       "prices": {
-        "usd": "0.47"
+        "usd": "0.47",
+        "eur": "0.58",
+        "tix": "0.19"
       }
     },
     {
@@ -8606,7 +8980,9 @@
       "edhrec_rank": 5365,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.12",
+        "eur": "0.20",
+        "tix": "0.02"
       }
     },
     {
@@ -8664,7 +9040,9 @@
       "edhrec_rank": 8805,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -8721,7 +9099,9 @@
       "edhrec_rank": 8650,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.14",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -8791,7 +9171,9 @@
       "edhrec_rank": 1051,
       "properties": [],
       "prices": {
-        "usd": "3.53"
+        "usd": "3.53",
+        "eur": "2.97",
+        "tix": "0.02"
       }
     },
     {
@@ -8832,7 +9214,9 @@
       "edhrec_rank": 6242,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.18",
+        "tix": "0.02"
       }
     },
     {
@@ -8876,7 +9260,9 @@
       "edhrec_rank": 2852,
       "properties": [],
       "prices": {
-        "usd": "0.73"
+        "usd": "0.73",
+        "eur": "0.60",
+        "tix": "0.02"
       }
     },
     {
@@ -8921,7 +9307,9 @@
       "edhrec_rank": 3656,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -8967,7 +9355,9 @@
       "edhrec_rank": 8850,
       "properties": [],
       "prices": {
-        "usd": "1.37"
+        "usd": "1.37",
+        "eur": "1.26",
+        "tix": "0.26"
       }
     },
     {
@@ -9012,7 +9402,9 @@
       "edhrec_rank": 3233,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.06",
+        "tix": "0.03"
       }
     },
     {
@@ -9057,7 +9449,9 @@
       "edhrec_rank": 3893,
       "properties": [],
       "prices": {
-        "usd": "0.70"
+        "usd": "0.70",
+        "eur": "0.45",
+        "tix": "0.02"
       }
     },
     {
@@ -9104,7 +9498,9 @@
       "edhrec_rank": 360,
       "properties": [],
       "prices": {
-        "usd": "0.44"
+        "usd": "0.44",
+        "eur": "0.59",
+        "tix": "0.03"
       }
     },
     {
@@ -9149,7 +9545,9 @@
       "edhrec_rank": 8723,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.18",
+        "tix": "0.03"
       }
     },
     {
@@ -9191,7 +9589,9 @@
       "edhrec_rank": 1750,
       "properties": [],
       "prices": {
-        "usd": "3.72"
+        "usd": "3.72",
+        "eur": "3.61",
+        "tix": "0.09"
       }
     },
     {
@@ -9239,7 +9639,9 @@
       "edhrec_rank": 10819,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.14",
+        "eur": "0.21",
+        "tix": "0.03"
       }
     },
     {
@@ -9280,7 +9682,9 @@
       "edhrec_rank": 4460,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.17",
+        "tix": "0.03"
       }
     },
     {
@@ -9324,7 +9728,9 @@
       "edhrec_rank": 10348,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.03",
+        "tix": "0.04"
       }
     },
     {
@@ -9371,7 +9777,9 @@
       "edhrec_rank": 2590,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -9423,7 +9831,9 @@
       "edhrec_rank": 6051,
       "properties": [],
       "prices": {
-        "usd": "4.05"
+        "usd": "4.05",
+        "eur": "1.74",
+        "tix": "0.52"
       }
     },
     {
@@ -9463,7 +9873,9 @@
       "edhrec_rank": 1596,
       "properties": [],
       "prices": {
-        "usd": "10.29"
+        "usd": "10.29",
+        "eur": "4.89",
+        "tix": "9.68"
       }
     },
     {
@@ -9495,7 +9907,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.15",
+        "tix": null
       }
     },
     {
@@ -9540,7 +9954,9 @@
       "edhrec_rank": 1280,
       "properties": [],
       "prices": {
-        "usd": "1.53"
+        "usd": "1.53",
+        "eur": "0.36",
+        "tix": "0.03"
       }
     },
     {
@@ -9599,7 +10015,9 @@
       "edhrec_rank": 3662,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.39",
+        "eur": "0.44",
+        "tix": "0.03"
       }
     },
     {
@@ -9645,7 +10063,9 @@
       "edhrec_rank": 10562,
       "properties": [],
       "prices": {
-        "usd": "0.81"
+        "usd": "0.81",
+        "eur": "1.05",
+        "tix": "0.16"
       }
     },
     {
@@ -9698,7 +10118,9 @@
       "edhrec_rank": 1373,
       "properties": [],
       "prices": {
-        "usd": "8.05"
+        "usd": "8.05",
+        "eur": "5.63",
+        "tix": "0.28"
       }
     },
     {
@@ -9768,7 +10190,9 @@
       "edhrec_rank": 1113,
       "properties": [],
       "prices": {
-        "usd": "6.48"
+        "usd": "6.48",
+        "eur": "5.63",
+        "tix": "0.29"
       }
     },
     {
@@ -9815,7 +10239,9 @@
       "edhrec_rank": 2520,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -9861,7 +10287,9 @@
       "edhrec_rank": 1366,
       "properties": [],
       "prices": {
-        "usd": "2.46"
+        "usd": "2.46",
+        "eur": "2.32",
+        "tix": "0.02"
       }
     },
     {
@@ -9904,7 +10332,9 @@
       "edhrec_rank": 287,
       "properties": [],
       "prices": {
-        "usd": "4.26"
+        "usd": "4.26",
+        "eur": "0.57",
+        "tix": "0.03"
       }
     },
     {
@@ -9949,7 +10379,9 @@
       "edhrec_rank": 313,
       "properties": [],
       "prices": {
-        "usd": "3.42"
+        "usd": "3.42",
+        "eur": "2.29",
+        "tix": "1.54"
       }
     },
     {
@@ -9991,7 +10423,9 @@
       "edhrec_rank": 18139,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.15",
+        "tix": "0.04"
       }
     },
     {
@@ -10036,7 +10470,9 @@
       "edhrec_rank": 399,
       "properties": [],
       "prices": {
-        "usd": "8.41"
+        "usd": "8.41",
+        "eur": "6.31",
+        "tix": "0.06"
       }
     },
     {
@@ -10082,7 +10518,9 @@
       "edhrec_rank": 2092,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -10122,7 +10560,9 @@
       "edhrec_rank": 396,
       "properties": [],
       "prices": {
-        "usd": "0.43"
+        "usd": "0.43",
+        "eur": "0.38",
+        "tix": "0.03"
       }
     },
     {
@@ -10180,7 +10620,9 @@
       "edhrec_rank": 3096,
       "properties": [],
       "prices": {
-        "usd": "2.14"
+        "usd": "2.14",
+        "eur": "2.11",
+        "tix": "0.36"
       }
     },
     {
@@ -10220,7 +10662,9 @@
       "edhrec_rank": 4582,
       "properties": [],
       "prices": {
-        "usd": "16.47"
+        "usd": "16.47",
+        "eur": "11.31",
+        "tix": null
       }
     },
     {
@@ -10264,7 +10708,9 @@
       "edhrec_rank": 2860,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.16",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -10308,7 +10754,9 @@
       "edhrec_rank": 4293,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.21",
+        "eur": "0.13",
+        "tix": "0.03"
       }
     },
     {
@@ -10352,7 +10800,9 @@
       "edhrec_rank": 3284,
       "properties": [],
       "prices": {
-        "usd": "0.11"
+        "usd": "0.11",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -10396,7 +10846,9 @@
       "edhrec_rank": 3557,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.09",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -10440,7 +10892,9 @@
       "edhrec_rank": 3056,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.16",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -10485,7 +10939,9 @@
       "edhrec_rank": 277,
       "properties": [],
       "prices": {
-        "usd": "5.08"
+        "usd": "5.08",
+        "eur": "4.04",
+        "tix": "0.02"
       }
     },
     {
@@ -10526,7 +10982,9 @@
       "edhrec_rank": 1713,
       "properties": [],
       "prices": {
-        "usd": "6.71"
+        "usd": "6.71",
+        "eur": "4.96",
+        "tix": "1.16"
       }
     },
     {
@@ -10570,7 +11028,9 @@
       "edhrec_rank": 2132,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.32",
+        "tix": "0.02"
       }
     },
     {
@@ -10615,7 +11075,9 @@
       "edhrec_rank": 960,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.43",
+        "tix": "0.34"
       }
     },
     {
@@ -10656,7 +11118,9 @@
       "edhrec_rank": 3565,
       "properties": [],
       "prices": {
-        "usd": "2.90"
+        "usd": "2.90",
+        "eur": "1.71",
+        "tix": "0.02"
       }
     },
     {
@@ -10696,7 +11160,9 @@
       "edhrec_rank": 2963,
       "properties": [],
       "prices": {
-        "usd": "3.99"
+        "usd": "3.99",
+        "eur": "1.95",
+        "tix": "2.22"
       }
     },
     {
@@ -10733,7 +11199,9 @@
       "edhrec_rank": 17150,
       "properties": [],
       "prices": {
-        "usd": "693.33"
+        "usd": "693.33",
+        "eur": "491.16",
+        "tix": null
       }
     },
     {
@@ -10764,7 +11232,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.13",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -10809,7 +11279,9 @@
       "edhrec_rank": 339,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.37",
+        "eur": "0.24",
+        "tix": "0.03"
       }
     },
     {
@@ -10855,7 +11327,9 @@
       "edhrec_rank": 1706,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.14",
+        "eur": "0.05",
+        "tix": "0.03"
       }
     },
     {
@@ -10917,7 +11391,9 @@
       "edhrec_rank": 15043,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.16",
+        "tix": "0.02"
       }
     },
     {
@@ -10989,7 +11465,9 @@
       "edhrec_rank": 494,
       "properties": [],
       "prices": {
-        "usd": "1.84"
+        "usd": "1.84",
+        "eur": "2.15",
+        "tix": "0.04"
       }
     },
     {
@@ -11033,7 +11511,9 @@
       "edhrec_rank": 953,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.19",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -11076,7 +11556,9 @@
       "edhrec_rank": 9181,
       "properties": [],
       "prices": {
-        "usd": "0.63"
+        "usd": "0.63",
+        "eur": "0.36",
+        "tix": "0.04"
       }
     },
     {
@@ -11120,7 +11602,9 @@
       "edhrec_rank": 87,
       "properties": [],
       "prices": {
-        "usd": "1.52"
+        "usd": "1.52",
+        "eur": "1.28",
+        "tix": "0.02"
       }
     },
     {
@@ -11161,7 +11645,9 @@
       "edhrec_rank": 5002,
       "properties": [],
       "prices": {
-        "usd": "0.42"
+        "usd": "0.42",
+        "eur": "0.55",
+        "tix": "0.02"
       }
     },
     {
@@ -11202,7 +11688,9 @@
       "edhrec_rank": 11446,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -11247,7 +11735,9 @@
       "edhrec_rank": 9501,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.15",
+        "tix": "0.03"
       }
     },
     {
@@ -11292,7 +11782,9 @@
       "edhrec_rank": 181,
       "properties": [],
       "prices": {
-        "usd": "1.39"
+        "usd": "1.39",
+        "eur": "1.31",
+        "tix": "0.02"
       }
     },
     {
@@ -11336,7 +11828,9 @@
       "edhrec_rank": 4685,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.28",
+        "tix": "0.04"
       }
     },
     {
@@ -11382,7 +11876,9 @@
       "edhrec_rank": 9020,
       "properties": [],
       "prices": {
-        "usd": "0.58"
+        "usd": "0.58",
+        "eur": "0.59",
+        "tix": "0.09"
       }
     },
     {
@@ -11429,7 +11925,9 @@
       "edhrec_rank": 2168,
       "properties": [],
       "prices": {
-        "usd": "1.18"
+        "usd": "1.18",
+        "eur": "0.94",
+        "tix": "0.03"
       }
     },
     {
@@ -11473,7 +11971,9 @@
       "edhrec_rank": 111,
       "properties": [],
       "prices": {
-        "usd": "1.99"
+        "usd": "1.99",
+        "eur": "1.68",
+        "tix": "0.02"
       }
     },
     {
@@ -11564,7 +12064,9 @@
       "edhrec_rank": 5704,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -11605,7 +12107,9 @@
       "edhrec_rank": 1977,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.17",
+        "eur": "0.21",
+        "tix": "0.02"
       }
     },
     {
@@ -11655,7 +12159,9 @@
       "edhrec_rank": 757,
       "properties": [],
       "prices": {
-        "usd": "5.82"
+        "usd": "5.82",
+        "eur": "2.76",
+        "tix": "2.40"
       }
     },
     {
@@ -11712,7 +12218,9 @@
       "edhrec_rank": 5332,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.20",
+        "tix": "0.03"
       }
     },
     {
@@ -11791,7 +12299,9 @@
       "edhrec_rank": 8633,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.31",
+        "eur": "0.32",
+        "tix": "0.02"
       }
     },
     {
@@ -11838,7 +12348,9 @@
       "edhrec_rank": 11989,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.19",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -11878,7 +12390,9 @@
       "edhrec_rank": 5117,
       "properties": [],
       "prices": {
-        "usd": "33.91"
+        "usd": "33.91",
+        "eur": "24.98",
+        "tix": "14.84"
       }
     },
     {
@@ -11920,7 +12434,9 @@
       "edhrec_rank": 16549,
       "properties": [],
       "prices": {
-        "usd": "1.38"
+        "usd": "1.38",
+        "eur": "1.09",
+        "tix": null
       }
     },
     {
@@ -11978,7 +12494,9 @@
       "edhrec_rank": 3070,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.18",
+        "tix": "0.03"
       }
     },
     {
@@ -12020,7 +12538,9 @@
       "edhrec_rank": 8335,
       "properties": [],
       "prices": {
-        "usd": "3.15"
+        "usd": "3.15",
+        "eur": "1.65",
+        "tix": null
       }
     },
     {
@@ -12062,7 +12582,9 @@
       "edhrec_rank": 10564,
       "properties": [],
       "prices": {
-        "usd": "1.01"
+        "usd": "1.01",
+        "eur": "1.02",
+        "tix": null
       }
     },
     {
@@ -12103,7 +12625,9 @@
       "edhrec_rank": 2418,
       "properties": [],
       "prices": {
-        "usd": "1.00"
+        "usd": "1.00",
+        "eur": "0.63",
+        "tix": "0.02"
       }
     },
     {
@@ -12135,7 +12659,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.64",
+        "tix": "0.03"
       }
     },
     {
@@ -12166,7 +12692,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "2.60"
+        "usd": "2.60",
+        "eur": "2.62",
+        "tix": "1.51"
       }
     },
     {
@@ -12209,7 +12737,9 @@
       "edhrec_rank": 4018,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -12253,7 +12783,9 @@
       "edhrec_rank": 9257,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -12296,7 +12828,9 @@
       "edhrec_rank": 3408,
       "properties": [],
       "prices": {
-        "usd": "13.37"
+        "usd": "13.37",
+        "eur": "8.86",
+        "tix": "0.02"
       }
     },
     {
@@ -12340,7 +12874,9 @@
       "edhrec_rank": 376,
       "properties": [],
       "prices": {
-        "usd": "6.43"
+        "usd": "6.43",
+        "eur": "6.43",
+        "tix": "0.12"
       }
     },
     {
@@ -12381,7 +12917,9 @@
       "edhrec_rank": 1592,
       "properties": [],
       "prices": {
-        "usd": "4.26"
+        "usd": "4.26",
+        "eur": "4.67",
+        "tix": "1.31"
       }
     },
     {
@@ -12427,7 +12965,9 @@
       "edhrec_rank": 776,
       "properties": [],
       "prices": {
-        "usd": "11.38"
+        "usd": "11.38",
+        "eur": "9.47",
+        "tix": "6.66"
       }
     },
     {
@@ -12467,7 +13007,9 @@
       "edhrec_rank": 21987,
       "properties": [],
       "prices": {
-        "usd": "292.66"
+        "usd": "292.66",
+        "eur": "144.17",
+        "tix": null
       }
     },
     {
@@ -12512,7 +13054,9 @@
       "edhrec_rank": 11186,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.31",
+        "tix": "0.04"
       }
     },
     {
@@ -12553,7 +13097,9 @@
       "edhrec_rank": 541,
       "properties": [],
       "prices": {
-        "usd": "4.50"
+        "usd": "4.50",
+        "eur": "2.39",
+        "tix": "0.03"
       }
     },
     {
@@ -12595,7 +13141,9 @@
       "edhrec_rank": 1062,
       "properties": [],
       "prices": {
-        "usd": "21.59"
+        "usd": "21.59",
+        "eur": "6.41",
+        "tix": "0.02"
       }
     },
     {
@@ -12681,7 +13229,9 @@
       "edhrec_rank": 2810,
       "properties": [],
       "prices": {
-        "usd": "5.55"
+        "usd": "5.55",
+        "eur": "2.99",
+        "tix": "0.38"
       }
     },
     {
@@ -12722,7 +13272,9 @@
       "edhrec_rank": 10202,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -12762,7 +13314,9 @@
       "edhrec_rank": 5958,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.30",
+        "tix": "0.02"
       }
     },
     {
@@ -12807,7 +13361,9 @@
       "edhrec_rank": 3533,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.20",
+        "tix": "0.03"
       }
     },
     {
@@ -12845,7 +13401,9 @@
       "edhrec_rank": 847,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.24",
+        "tix": "0.03"
       }
     },
     {
@@ -12886,7 +13444,9 @@
       "edhrec_rank": 5861,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -12931,7 +13491,9 @@
       "edhrec_rank": 10618,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.16",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -12973,7 +13535,9 @@
       "edhrec_rank": 4544,
       "properties": [],
       "prices": {
-        "usd": "0.42"
+        "usd": "0.42",
+        "eur": "1.16",
+        "tix": "18.78"
       }
     },
     {
@@ -13016,7 +13580,9 @@
       "edhrec_rank": 1218,
       "properties": [],
       "prices": {
-        "usd": "15.42"
+        "usd": "15.42",
+        "eur": "13.01",
+        "tix": "0.34"
       }
     },
     {
@@ -13059,7 +13625,9 @@
       "edhrec_rank": 10258,
       "properties": [],
       "prices": {
-        "usd": "1.95"
+        "usd": "1.95",
+        "eur": "0.27",
+        "tix": "0.15"
       }
     },
     {
@@ -13097,7 +13665,9 @@
       "edhrec_rank": 18,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.18",
+        "eur": "0.18",
+        "tix": "0.03"
       }
     },
     {
@@ -13142,7 +13712,9 @@
       "edhrec_rank": 9,
       "properties": [],
       "prices": {
-        "usd": "2.34"
+        "usd": "2.34",
+        "eur": "0.70",
+        "tix": "0.02"
       }
     },
     {
@@ -13180,7 +13752,9 @@
       "edhrec_rank": 2791,
       "properties": [],
       "prices": {
-        "usd": "63.32"
+        "usd": "63.32",
+        "eur": "44.03",
+        "tix": "0.28"
       }
     },
     {
@@ -13218,7 +13792,9 @@
       "edhrec_rank": 53,
       "properties": [],
       "prices": {
-        "usd": "2.61"
+        "usd": "2.61",
+        "eur": "3.28",
+        "tix": "0.02"
       }
     },
     {
@@ -13259,7 +13835,9 @@
       "edhrec_rank": 7599,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.20",
+        "tix": "0.02"
       }
     },
     {
@@ -13301,7 +13879,9 @@
       "edhrec_rank": 4664,
       "properties": [],
       "prices": {
-        "usd": "1.59"
+        "usd": "1.59",
+        "eur": "2.54",
+        "tix": "1.10"
       }
     },
     {
@@ -13371,7 +13951,9 @@
       "edhrec_rank": 207,
       "properties": [],
       "prices": {
-        "usd": "3.20"
+        "usd": "3.20",
+        "eur": "4.71",
+        "tix": "0.07"
       }
     },
     {
@@ -13416,7 +13998,9 @@
       "edhrec_rank": 778,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.41",
+        "eur": "0.48",
+        "tix": "0.27"
       }
     },
     {
@@ -13458,7 +14042,9 @@
       "edhrec_rank": 10295,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.16",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -13503,7 +14089,9 @@
       "edhrec_rank": 4891,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.23",
+        "tix": "0.03"
       }
     },
     {
@@ -13549,7 +14137,9 @@
       "edhrec_rank": 2301,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.51",
+        "tix": "0.65"
       }
     },
     {
@@ -13595,7 +14185,9 @@
       "edhrec_rank": 350,
       "properties": [],
       "prices": {
-        "usd": "6.32"
+        "usd": "6.32",
+        "eur": "2.88",
+        "tix": "0.03"
       }
     },
     {
@@ -13641,7 +14233,9 @@
       "edhrec_rank": 862,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.43",
+        "tix": "0.02"
       }
     },
     {
@@ -13681,7 +14275,9 @@
       "edhrec_rank": 857,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.20",
+        "tix": "0.03"
       }
     },
     {
@@ -13737,7 +14333,9 @@
       "edhrec_rank": 448,
       "properties": [],
       "prices": {
-        "usd": "33.28"
+        "usd": "33.28",
+        "eur": "27.87",
+        "tix": "0.02"
       }
     },
     {
@@ -13770,7 +14368,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.06",
+        "tix": "0.01"
       }
     },
     {
@@ -13815,7 +14415,9 @@
       "edhrec_rank": 815,
       "properties": [],
       "prices": {
-        "usd": "6.03"
+        "usd": "6.03",
+        "eur": "4.39",
+        "tix": "10.78"
       }
     },
     {
@@ -13844,7 +14446,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "2.16"
+        "usd": "2.16",
+        "eur": "1.15",
+        "tix": "0.02"
       }
     },
     {
@@ -13890,7 +14494,9 @@
       "edhrec_rank": 1252,
       "properties": [],
       "prices": {
-        "usd": "9.38"
+        "usd": "9.38",
+        "eur": "5.42",
+        "tix": "0.02"
       }
     },
     {
@@ -13933,7 +14539,9 @@
       "edhrec_rank": 3201,
       "properties": [],
       "prices": {
-        "usd": "4.53"
+        "usd": "4.53",
+        "eur": "3.29",
+        "tix": "0.12"
       }
     },
     {
@@ -13975,7 +14583,9 @@
       "edhrec_rank": 3641,
       "properties": [],
       "prices": {
-        "usd": "1.85"
+        "usd": "1.85",
+        "eur": "1.19",
+        "tix": "2.18"
       }
     },
     {
@@ -14012,7 +14622,9 @@
       "edhrec_rank": 5182,
       "properties": [],
       "prices": {
-        "usd": "1.30"
+        "usd": "1.30",
+        "eur": "1.00",
+        "tix": "0.05"
       }
     },
     {
@@ -14058,7 +14670,9 @@
       "edhrec_rank": 309,
       "properties": [],
       "prices": {
-        "usd": "4.89"
+        "usd": "4.89",
+        "eur": "1.57",
+        "tix": "0.02"
       }
     },
     {
@@ -14095,7 +14709,9 @@
       "edhrec_rank": 39,
       "properties": [],
       "prices": {
-        "usd": "113.52"
+        "usd": "113.52",
+        "eur": "61.57",
+        "tix": "12.76"
       }
     },
     {
@@ -14140,7 +14756,9 @@
       "edhrec_rank": 714,
       "properties": [],
       "prices": {
-        "usd": "8.25"
+        "usd": "8.25",
+        "eur": "9.32",
+        "tix": "0.37"
       }
     },
     {
@@ -14171,7 +14789,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.05",
+        "tix": "0.03"
       }
     },
     {
@@ -14211,7 +14831,9 @@
       "edhrec_rank": 1641,
       "properties": [],
       "prices": {
-        "usd": "10.07"
+        "usd": "10.07",
+        "eur": "9.71",
+        "tix": "0.03"
       }
     },
     {
@@ -14242,7 +14864,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.12",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -14302,7 +14926,9 @@
       "edhrec_rank": 689,
       "properties": [],
       "prices": {
-        "usd": "9.19"
+        "usd": "9.19",
+        "eur": "5.21",
+        "tix": "0.02"
       }
     },
     {
@@ -14344,7 +14970,9 @@
       "edhrec_rank": 10684,
       "properties": [],
       "prices": {
-        "usd": "0.44"
+        "usd": "0.44",
+        "eur": "0.46",
+        "tix": "0.04"
       }
     },
     {
@@ -14390,7 +15018,9 @@
       "edhrec_rank": 1651,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.15",
+        "tix": "0.03"
       }
     },
     {
@@ -14435,7 +15065,9 @@
       "edhrec_rank": 326,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.32",
+        "tix": "0.02"
       }
     },
     {
@@ -14476,7 +15108,9 @@
       "edhrec_rank": 2169,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.31",
+        "eur": "0.37",
+        "tix": null
       }
     },
     {
@@ -14520,7 +15154,9 @@
       "edhrec_rank": 811,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.31",
+        "eur": "0.33",
+        "tix": "0.04"
       }
     },
     {
@@ -14566,7 +15202,9 @@
       "edhrec_rank": 13347,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.16",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -14611,7 +15249,9 @@
       "edhrec_rank": 4845,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.22",
+        "tix": "0.03"
       }
     },
     {
@@ -14655,7 +15295,9 @@
       "edhrec_rank": 22220,
       "properties": [],
       "prices": {
-        "usd": "10.31"
+        "usd": "10.31",
+        "eur": "10.55",
+        "tix": "16.15"
       }
     },
     {
@@ -14700,7 +15342,9 @@
       "edhrec_rank": 6146,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -14744,7 +15388,9 @@
       "edhrec_rank": 12169,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.33",
+        "tix": "0.03"
       }
     },
     {
@@ -14788,7 +15434,9 @@
       "edhrec_rank": 342,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.26",
+        "tix": "0.02"
       }
     },
     {
@@ -14821,7 +15469,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.17",
+        "eur": "0.07",
+        "tix": "0.01"
       }
     },
     {
@@ -14866,7 +15516,9 @@
       "edhrec_rank": 5064,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.18",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -14924,7 +15576,9 @@
       "edhrec_rank": 15046,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.18",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -14981,7 +15635,9 @@
       "edhrec_rank": 9686,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.10",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -15023,7 +15679,9 @@
       "edhrec_rank": 20118,
       "properties": [],
       "prices": {
-        "usd": "0.42"
+        "usd": "0.42",
+        "eur": "0.26",
+        "tix": "0.11"
       }
     },
     {
@@ -15088,7 +15746,9 @@
       "edhrec_rank": 993,
       "properties": [],
       "prices": {
-        "usd": "3.79"
+        "usd": "3.79",
+        "eur": "3.38",
+        "tix": "0.17"
       }
     },
     {
@@ -15136,7 +15796,9 @@
       "edhrec_rank": 389,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.20",
+        "tix": "0.03"
       }
     },
     {
@@ -15181,7 +15843,9 @@
       "edhrec_rank": 11611,
       "properties": [],
       "prices": {
-        "usd": "0.78"
+        "usd": "0.78",
+        "eur": "0.74",
+        "tix": "0.03"
       }
     },
     {
@@ -15227,7 +15891,9 @@
       "edhrec_rank": 344,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.39",
+        "tix": "0.02"
       }
     },
     {
@@ -15267,7 +15933,9 @@
       "edhrec_rank": 9994,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -15312,7 +15980,9 @@
       "edhrec_rank": 15035,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -15358,7 +16028,9 @@
       "edhrec_rank": 348,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.40",
+        "tix": "0.02"
       }
     },
     {
@@ -15401,7 +16073,9 @@
       "edhrec_rank": 452,
       "properties": [],
       "prices": {
-        "usd": "1495.77"
+        "usd": "1495.77",
+        "eur": "1071.78",
+        "tix": "16.66"
       }
     },
     {
@@ -15448,7 +16122,9 @@
       "edhrec_rank": 5471,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.35",
+        "tix": null
       }
     },
     {
@@ -15492,7 +16168,9 @@
       "edhrec_rank": 367,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.59",
+        "tix": "0.02"
       }
     },
     {
@@ -15549,7 +16227,9 @@
       "edhrec_rank": 13921,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.18",
+        "eur": "0.25",
+        "tix": "0.02"
       }
     },
     {
@@ -15592,7 +16272,9 @@
       "edhrec_rank": 13016,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.16",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -15637,7 +16319,9 @@
       "edhrec_rank": 2500,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.21",
+        "eur": "0.06",
+        "tix": "0.03"
       }
     },
     {
@@ -15681,7 +16365,9 @@
       "edhrec_rank": 955,
       "properties": [],
       "prices": {
-        "usd": "4.51"
+        "usd": "4.51",
+        "eur": "2.92",
+        "tix": "0.02"
       }
     },
     {
@@ -15722,7 +16408,9 @@
       "edhrec_rank": 429,
       "properties": [],
       "prices": {
-        "usd": "2.19"
+        "usd": "2.19",
+        "eur": "1.44",
+        "tix": "0.02"
       }
     },
     {
@@ -15767,7 +16455,9 @@
       "edhrec_rank": 179,
       "properties": [],
       "prices": {
-        "usd": "51.43"
+        "usd": "51.43",
+        "eur": "30.74",
+        "tix": "1.29"
       }
     },
     {
@@ -15811,7 +16501,9 @@
       "edhrec_rank": 3344,
       "properties": [],
       "prices": {
-        "usd": "13.14"
+        "usd": "13.14",
+        "eur": "6.97",
+        "tix": "13.36"
       }
     },
     {
@@ -15856,7 +16548,9 @@
       "edhrec_rank": 2270,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -15902,7 +16596,9 @@
       "edhrec_rank": 20595,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.66",
+        "tix": "0.91"
       }
     },
     {
@@ -15944,7 +16640,9 @@
       "edhrec_rank": 11656,
       "properties": [],
       "prices": {
-        "usd": "0.43"
+        "usd": "0.43",
+        "eur": "0.71",
+        "tix": "0.04"
       }
     },
     {
@@ -15985,7 +16683,9 @@
       "edhrec_rank": 773,
       "properties": [],
       "prices": {
-        "usd": "5.32"
+        "usd": "5.32",
+        "eur": "0.85",
+        "tix": "0.05"
       }
     },
     {
@@ -16026,7 +16726,9 @@
       "edhrec_rank": 6887,
       "properties": [],
       "prices": {
-        "usd": "4.55"
+        "usd": "4.55",
+        "eur": "1.53",
+        "tix": "0.18"
       }
     },
     {
@@ -16071,7 +16773,9 @@
       "edhrec_rank": 5003,
       "properties": [],
       "prices": {
-        "usd": "10.44"
+        "usd": "10.44",
+        "eur": "3.29",
+        "tix": "0.02"
       }
     },
     {
@@ -16131,7 +16835,9 @@
       "edhrec_rank": 2751,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.17",
+        "tix": "0.03"
       }
     },
     {
@@ -16170,7 +16876,9 @@
       "edhrec_rank": 2172,
       "properties": [],
       "prices": {
-        "usd": "22.26"
+        "usd": "22.26",
+        "eur": "17.02",
+        "tix": null
       }
     },
     {
@@ -16215,7 +16923,9 @@
       "edhrec_rank": 3840,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.39",
+        "eur": "0.36",
+        "tix": "0.03"
       }
     },
     {
@@ -16259,7 +16969,9 @@
       "edhrec_rank": 99,
       "properties": [],
       "prices": {
-        "usd": "1.09"
+        "usd": "1.09",
+        "eur": "0.82",
+        "tix": "0.02"
       }
     },
     {
@@ -16331,7 +17043,9 @@
       "edhrec_rank": 1180,
       "properties": [],
       "prices": {
-        "usd": "6.32"
+        "usd": "6.32",
+        "eur": "5.85",
+        "tix": "0.02"
       }
     },
     {
@@ -16407,7 +17121,9 @@
       "edhrec_rank": 2842,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.37",
+        "eur": "0.24",
+        "tix": "0.03"
       }
     },
     {
@@ -16449,7 +17165,9 @@
       "edhrec_rank": 6153,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.22",
+        "tix": "0.03"
       }
     },
     {
@@ -16494,7 +17212,9 @@
       "edhrec_rank": 4688,
       "properties": [],
       "prices": {
-        "usd": "4.14"
+        "usd": "4.14",
+        "eur": "3.10",
+        "tix": "0.02"
       }
     },
     {
@@ -16540,7 +17260,9 @@
       "edhrec_rank": 3880,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.38",
+        "tix": "0.72"
       }
     },
     {
@@ -16585,7 +17307,9 @@
       "edhrec_rank": 634,
       "properties": [],
       "prices": {
-        "usd": "11.02"
+        "usd": "11.02",
+        "eur": "10.42",
+        "tix": "0.30"
       }
     },
     {
@@ -16644,7 +17368,9 @@
       "edhrec_rank": 17103,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.05",
+        "tix": "0.03"
       }
     },
     {
@@ -16686,7 +17412,9 @@
       "edhrec_rank": 10119,
       "properties": [],
       "prices": {
-        "usd": "0.51"
+        "usd": "0.51",
+        "eur": "0.25",
+        "tix": "0.04"
       }
     },
     {
@@ -16731,7 +17459,9 @@
       "edhrec_rank": 60,
       "properties": [],
       "prices": {
-        "usd": "15.98"
+        "usd": "15.98",
+        "eur": "10.06",
+        "tix": "0.09"
       }
     },
     {
@@ -16788,7 +17518,9 @@
       "edhrec_rank": 12995,
       "properties": [],
       "prices": {
-        "usd": "1.00"
+        "usd": "1.00",
+        "eur": "0.40",
+        "tix": "0.03"
       }
     },
     {
@@ -16833,7 +17565,9 @@
       "edhrec_rank": 5954,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -16880,7 +17614,9 @@
       "edhrec_rank": 2097,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.17",
+        "tix": "0.03"
       }
     },
     {
@@ -16926,7 +17662,9 @@
       "edhrec_rank": 1502,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.06",
+        "tix": "0.03"
       }
     },
     {
@@ -16971,7 +17709,9 @@
       "edhrec_rank": 315,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.23",
+        "tix": "0.03"
       }
     },
     {
@@ -17016,7 +17756,9 @@
       "edhrec_rank": 2462,
       "properties": [],
       "prices": {
-        "usd": "1.27"
+        "usd": "1.27",
+        "eur": "0.81",
+        "tix": null
       }
     },
     {
@@ -17061,7 +17803,9 @@
       "edhrec_rank": 5967,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -17106,7 +17850,9 @@
       "edhrec_rank": 4765,
       "properties": [],
       "prices": {
-        "usd": "6.94"
+        "usd": "6.94",
+        "eur": "6.35",
+        "tix": "0.69"
       }
     },
     {
@@ -17146,7 +17892,9 @@
       "edhrec_rank": 7397,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.31",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -17183,7 +17931,9 @@
       "edhrec_rank": 4651,
       "properties": [],
       "prices": {
-        "usd": "0.68"
+        "usd": "0.68",
+        "eur": "0.65",
+        "tix": "0.04"
       }
     },
     {
@@ -17229,7 +17979,9 @@
       "edhrec_rank": 583,
       "properties": [],
       "prices": {
-        "usd": "7.51"
+        "usd": "7.51",
+        "eur": "3.40",
+        "tix": "0.02"
       }
     },
     {
@@ -17273,7 +18025,9 @@
       "edhrec_rank": 2809,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.17",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -17332,7 +18086,9 @@
       "edhrec_rank": 7289,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.20",
+        "tix": "0.02"
       }
     },
     {
@@ -17375,7 +18131,9 @@
       "edhrec_rank": 405,
       "properties": [],
       "prices": {
-        "usd": "2.81"
+        "usd": "2.81",
+        "eur": "2.17",
+        "tix": "6.28"
       }
     },
     {
@@ -17434,7 +18192,9 @@
       "edhrec_rank": 14916,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.14",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -17466,7 +18226,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.48"
+        "usd": "0.48",
+        "eur": "0.58",
+        "tix": "0.19"
       }
     },
     {
@@ -17512,7 +18274,9 @@
       "edhrec_rank": 1818,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -17553,7 +18317,9 @@
       "edhrec_rank": 17305,
       "properties": [],
       "prices": {
-        "usd": "5.68"
+        "usd": "5.68",
+        "eur": "5.18",
+        "tix": "0.62"
       }
     },
     {
@@ -17597,7 +18363,9 @@
       "edhrec_rank": 2064,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.35",
+        "tix": "0.02"
       }
     },
     {
@@ -17638,7 +18406,9 @@
       "edhrec_rank": 5546,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.49",
+        "tix": "0.03"
       }
     },
     {
@@ -17684,7 +18454,9 @@
       "edhrec_rank": 3340,
       "properties": [],
       "prices": {
-        "usd": "16.01"
+        "usd": "16.01",
+        "eur": "7.09",
+        "tix": "1.05"
       }
     },
     {
@@ -17744,7 +18516,9 @@
       "edhrec_rank": 10916,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.31",
+        "eur": "0.23",
+        "tix": "0.02"
       }
     },
     {
@@ -17790,7 +18564,9 @@
       "edhrec_rank": 2027,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -17835,7 +18611,9 @@
       "edhrec_rank": 413,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.27",
+        "tix": "0.03"
       }
     },
     {
@@ -17880,7 +18658,9 @@
       "edhrec_rank": 5500,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -17920,7 +18700,9 @@
       "edhrec_rank": 1243,
       "properties": [],
       "prices": {
-        "usd": "1.43"
+        "usd": "1.43",
+        "eur": "2.07",
+        "tix": "1.02"
       }
     },
     {
@@ -17965,7 +18747,9 @@
       "edhrec_rank": 9256,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.25",
+        "tix": "0.02"
       }
     },
     {
@@ -18035,7 +18819,9 @@
       "edhrec_rank": 2002,
       "properties": [],
       "prices": {
-        "usd": "2.14"
+        "usd": "2.14",
+        "eur": "1.39",
+        "tix": "0.02"
       }
     },
     {
@@ -18077,7 +18863,9 @@
       "edhrec_rank": 1267,
       "properties": [],
       "prices": {
-        "usd": "0.68"
+        "usd": "0.68",
+        "eur": "0.46",
+        "tix": "0.03"
       }
     },
     {
@@ -18139,7 +18927,9 @@
       "edhrec_rank": 14544,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.17",
+        "tix": "0.02"
       }
     },
     {
@@ -18182,7 +18972,9 @@
       "edhrec_rank": 419,
       "properties": [],
       "prices": {
-        "usd": "11.74"
+        "usd": "11.74",
+        "eur": "8.51",
+        "tix": "0.02"
       }
     },
     {
@@ -18227,7 +19019,9 @@
       "edhrec_rank": 5925,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.41",
+        "eur": "0.33",
+        "tix": "0.02"
       }
     },
     {
@@ -18269,7 +19063,9 @@
       "edhrec_rank": 5333,
       "properties": [],
       "prices": {
-        "usd": "0.55"
+        "usd": "0.55",
+        "eur": "1.09",
+        "tix": "0.02"
       }
     },
     {
@@ -18338,7 +19134,9 @@
       "edhrec_rank": 6080,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.39",
+        "eur": "0.24",
+        "tix": "0.02"
       }
     },
     {
@@ -18378,7 +19176,9 @@
       "edhrec_rank": 2965,
       "properties": [],
       "prices": {
-        "usd": "20.06"
+        "usd": "20.06",
+        "eur": "6.50",
+        "tix": "0.02"
       }
     },
     {
@@ -18423,7 +19223,9 @@
       "edhrec_rank": 65,
       "properties": [],
       "prices": {
-        "usd": "21.40"
+        "usd": "21.40",
+        "eur": "11.03",
+        "tix": "0.26"
       }
     },
     {
@@ -18462,7 +19264,9 @@
       "edhrec_rank": 19594,
       "properties": [],
       "prices": {
-        "usd": "3.03"
+        "usd": "3.03",
+        "eur": "1.82",
+        "tix": null
       }
     },
     {
@@ -18505,7 +19309,9 @@
       "edhrec_rank": 9380,
       "properties": [],
       "prices": {
-        "usd": "14.15"
+        "usd": "14.15",
+        "eur": "18.46",
+        "tix": null
       }
     },
     {
@@ -18579,7 +19385,9 @@
       "edhrec_rank": 3104,
       "properties": [],
       "prices": {
-        "usd": "1.93"
+        "usd": "1.93",
+        "eur": "1.26",
+        "tix": "0.02"
       }
     },
     {
@@ -18622,7 +19430,9 @@
       "edhrec_rank": 4031,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.27",
+        "tix": "0.03"
       }
     },
     {
@@ -18663,7 +19473,9 @@
       "edhrec_rank": 7259,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.13",
+        "tix": "0.03"
       }
     },
     {
@@ -18708,7 +19520,9 @@
       "edhrec_rank": 1207,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.41",
+        "tix": "0.03"
       }
     },
     {
@@ -18753,7 +19567,9 @@
       "edhrec_rank": 275,
       "properties": [],
       "prices": {
-        "usd": "7.84"
+        "usd": "7.84",
+        "eur": "5.31",
+        "tix": "0.03"
       }
     },
     {
@@ -18798,7 +19614,9 @@
       "edhrec_rank": 1137,
       "properties": [],
       "prices": {
-        "usd": "1.81"
+        "usd": "1.81",
+        "eur": "1.02",
+        "tix": "0.02"
       }
     },
     {
@@ -18887,7 +19705,9 @@
       "edhrec_rank": 8697,
       "properties": [],
       "prices": {
-        "usd": "5.78"
+        "usd": "5.78",
+        "eur": "3.27",
+        "tix": null
       }
     },
     {
@@ -18929,7 +19749,9 @@
       "edhrec_rank": 8616,
       "properties": [],
       "prices": {
-        "usd": "1.34"
+        "usd": "1.34",
+        "eur": "2.63",
+        "tix": null
       }
     },
     {
@@ -18992,7 +19814,9 @@
       "edhrec_rank": 2949,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.56",
+        "tix": "0.47"
       }
     },
     {
@@ -19034,7 +19858,9 @@
       "edhrec_rank": 23612,
       "properties": [],
       "prices": {
-        "usd": "2.43"
+        "usd": "2.43",
+        "eur": "1.47",
+        "tix": null
       }
     },
     {
@@ -19080,7 +19906,9 @@
       "edhrec_rank": 543,
       "properties": [],
       "prices": {
-        "usd": "12.95"
+        "usd": "12.95",
+        "eur": "12.08",
+        "tix": "3.10"
       }
     },
     {
@@ -19137,7 +19965,9 @@
       "edhrec_rank": 4831,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.42",
+        "tix": "2.13"
       }
     },
     {
@@ -19195,7 +20025,9 @@
       "edhrec_rank": 20693,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.21",
+        "tix": "0.02"
       }
     },
     {
@@ -19241,7 +20073,9 @@
       "edhrec_rank": 26274,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.24",
+        "tix": "0.04"
       }
     },
     {
@@ -19311,7 +20145,9 @@
       "edhrec_rank": 1152,
       "properties": [],
       "prices": {
-        "usd": "5.41"
+        "usd": "5.41",
+        "eur": "5.01",
+        "tix": "0.03"
       }
     },
     {
@@ -19353,7 +20189,9 @@
       "edhrec_rank": 6589,
       "properties": [],
       "prices": {
-        "usd": "3.52"
+        "usd": "3.52",
+        "eur": "3.27",
+        "tix": "19.71"
       }
     },
     {
@@ -19397,7 +20235,9 @@
       "edhrec_rank": 4729,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.16",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -19441,7 +20281,9 @@
       "edhrec_rank": 5095,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -19488,7 +20330,9 @@
       "edhrec_rank": 2323,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -19519,7 +20363,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "3.14"
+        "usd": "3.14",
+        "eur": "1.77",
+        "tix": "1.65"
       }
     },
     {
@@ -19561,7 +20407,9 @@
       "edhrec_rank": 5311,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -19605,7 +20453,9 @@
       "edhrec_rank": 3256,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.17",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -19649,7 +20499,9 @@
       "edhrec_rank": 3664,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -19690,7 +20542,9 @@
       "edhrec_rank": 467,
       "properties": [],
       "prices": {
-        "usd": "8.38"
+        "usd": "8.38",
+        "eur": "5.15",
+        "tix": "0.19"
       }
     },
     {
@@ -19735,7 +20589,9 @@
       "edhrec_rank": 3138,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.47",
+        "tix": "0.03"
       }
     },
     {
@@ -19780,7 +20636,9 @@
       "edhrec_rank": 6113,
       "properties": [],
       "prices": {
-        "usd": "0.11"
+        "usd": "0.11",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -19825,7 +20683,9 @@
       "edhrec_rank": 16398,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.15",
+        "tix": "0.03"
       }
     },
     {
@@ -19870,7 +20730,9 @@
       "edhrec_rank": 100,
       "properties": [],
       "prices": {
-        "usd": "0.86"
+        "usd": "0.86",
+        "eur": "0.63",
+        "tix": "0.02"
       }
     },
     {
@@ -19914,7 +20776,9 @@
       "edhrec_rank": 6722,
       "properties": [],
       "prices": {
-        "usd": "0.85"
+        "usd": "0.85",
+        "eur": "0.50",
+        "tix": "0.02"
       }
     },
     {
@@ -19956,7 +20820,9 @@
       "edhrec_rank": 7606,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.39",
+        "eur": "0.99",
+        "tix": "0.02"
       }
     },
     {
@@ -20002,7 +20868,9 @@
       "edhrec_rank": 2990,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.31",
+        "tix": "0.03"
       }
     },
     {
@@ -20044,7 +20912,9 @@
       "edhrec_rank": 18417,
       "properties": [],
       "prices": {
-        "usd": "1.13"
+        "usd": "1.13",
+        "eur": "0.83",
+        "tix": null
       }
     },
     {
@@ -20085,7 +20955,9 @@
       "edhrec_rank": 1170,
       "properties": [],
       "prices": {
-        "usd": "15.80"
+        "usd": "15.80",
+        "eur": "10.00",
+        "tix": "4.48"
       }
     },
     {
@@ -20130,7 +21002,9 @@
       "edhrec_rank": 1662,
       "properties": [],
       "prices": {
-        "usd": "6.53"
+        "usd": "6.53",
+        "eur": "3.66",
+        "tix": "0.02"
       }
     },
     {
@@ -20174,7 +21048,9 @@
       "edhrec_rank": 1458,
       "properties": [],
       "prices": {
-        "usd": "6.63"
+        "usd": "6.63",
+        "eur": "5.41",
+        "tix": "4.56"
       }
     },
     {
@@ -20215,7 +21091,9 @@
       "edhrec_rank": 9347,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.17",
+        "tix": "0.02"
       }
     },
     {
@@ -20290,7 +21168,9 @@
       "edhrec_rank": 10109,
       "properties": [],
       "prices": {
-        "usd": "0.52"
+        "usd": "0.52",
+        "eur": "0.85",
+        "tix": "0.02"
       }
     },
     {
@@ -20334,7 +21214,9 @@
       "edhrec_rank": 20538,
       "properties": [],
       "prices": {
-        "usd": "0.59"
+        "usd": "0.59",
+        "eur": "0.29",
+        "tix": "0.02"
       }
     },
     {
@@ -20379,7 +21261,9 @@
       "edhrec_rank": 760,
       "properties": [],
       "prices": {
-        "usd": "7.65"
+        "usd": "7.65",
+        "eur": "5.28",
+        "tix": "0.26"
       }
     },
     {
@@ -20453,7 +21337,9 @@
       "edhrec_rank": 621,
       "properties": [],
       "prices": {
-        "usd": "0.78"
+        "usd": "0.78",
+        "eur": "1.31",
+        "tix": "0.03"
       }
     },
     {
@@ -20495,7 +21381,9 @@
       "edhrec_rank": 19527,
       "properties": [],
       "prices": {
-        "usd": "0.72"
+        "usd": "0.72",
+        "eur": "0.65",
+        "tix": null
       }
     },
     {
@@ -20532,7 +21420,9 @@
       "edhrec_rank": 16114,
       "properties": [],
       "prices": {
-        "usd": "0.52"
+        "usd": "0.52",
+        "eur": "0.46",
+        "tix": null
       }
     },
     {
@@ -20577,7 +21467,9 @@
       "edhrec_rank": 3977,
       "properties": [],
       "prices": {
-        "usd": "0.45"
+        "usd": "0.45",
+        "eur": "0.62",
+        "tix": "0.03"
       }
     },
     {
@@ -20622,7 +21514,9 @@
       "edhrec_rank": 2253,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.26",
+        "eur": "0.24",
+        "tix": "0.03"
       }
     },
     {
@@ -20665,7 +21559,9 @@
       "edhrec_rank": 4226,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.27",
+        "tix": "0.03"
       }
     },
     {
@@ -20708,7 +21604,9 @@
       "edhrec_rank": 4699,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.22",
+        "tix": "0.03"
       }
     },
     {
@@ -20739,7 +21637,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.16",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -20782,7 +21682,9 @@
       "edhrec_rank": 16561,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.17",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -20831,7 +21733,9 @@
       "edhrec_rank": 462,
       "properties": [],
       "prices": {
-        "usd": "20.09"
+        "usd": "20.09",
+        "eur": "16.86",
+        "tix": "6.52"
       }
     },
     {
@@ -20888,7 +21792,9 @@
       "edhrec_rank": 2016,
       "properties": [],
       "prices": {
-        "usd": "12.47"
+        "usd": "12.47",
+        "eur": "8.38",
+        "tix": "0.21"
       }
     },
     {
@@ -20933,7 +21839,9 @@
       "edhrec_rank": 5617,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -20978,7 +21886,9 @@
       "edhrec_rank": 1465,
       "properties": [],
       "prices": {
-        "usd": "1.53"
+        "usd": "1.53",
+        "eur": "1.92",
+        "tix": "0.23"
       }
     },
     {
@@ -21023,7 +21933,9 @@
       "edhrec_rank": 4317,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.15",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -21064,7 +21976,9 @@
       "edhrec_rank": 280,
       "properties": [],
       "prices": {
-        "usd": "14.18"
+        "usd": "14.18",
+        "eur": "9.54",
+        "tix": "0.02"
       }
     },
     {
@@ -21109,7 +22023,9 @@
       "edhrec_rank": 9254,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.22",
+        "tix": "0.03"
       }
     },
     {
@@ -21155,7 +22071,9 @@
       "edhrec_rank": 804,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.21",
+        "tix": "0.02"
       }
     },
     {
@@ -21201,7 +22119,9 @@
       "edhrec_rank": 22959,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.20",
+        "tix": "0.07"
       }
     },
     {
@@ -21264,7 +22184,9 @@
       "edhrec_rank": 1634,
       "properties": [],
       "prices": {
-        "usd": "2.54"
+        "usd": "2.54",
+        "eur": "1.14",
+        "tix": "0.02"
       }
     },
     {
@@ -21302,7 +22224,9 @@
       "edhrec_rank": 21991,
       "properties": [],
       "prices": {
-        "usd": "235.12"
+        "usd": "235.12",
+        "eur": "224.86",
+        "tix": null
       }
     },
     {
@@ -21347,7 +22271,9 @@
       "edhrec_rank": 93,
       "properties": [],
       "prices": {
-        "usd": "1.23"
+        "usd": "1.23",
+        "eur": "1.20",
+        "tix": "0.02"
       }
     },
     {
@@ -21389,7 +22315,9 @@
       "edhrec_rank": 10308,
       "properties": [],
       "prices": {
-        "usd": "1.05"
+        "usd": "1.05",
+        "eur": "0.88",
+        "tix": null
       }
     },
     {
@@ -21434,7 +22362,9 @@
       "edhrec_rank": 393,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.17",
+        "tix": "0.03"
       }
     },
     {
@@ -21480,7 +22410,9 @@
       "edhrec_rank": 1670,
       "properties": [],
       "prices": {
-        "usd": "0.07"
+        "usd": "0.07",
+        "eur": "0.05",
+        "tix": "0.03"
       }
     },
     {
@@ -21525,7 +22457,9 @@
       "edhrec_rank": 3388,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.41",
+        "eur": "1.28",
+        "tix": "0.94"
       }
     },
     {
@@ -21557,7 +22491,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.73"
+        "usd": "0.73",
+        "eur": "0.54",
+        "tix": "0.03"
       }
     },
     {
@@ -21607,7 +22543,9 @@
       "edhrec_rank": 354,
       "properties": [],
       "prices": {
-        "usd": "17.46"
+        "usd": "17.46",
+        "eur": "12.95",
+        "tix": "0.14"
       }
     },
     {
@@ -21672,7 +22610,9 @@
       "edhrec_rank": 2469,
       "properties": [],
       "prices": {
-        "usd": "1.67"
+        "usd": "1.67",
+        "eur": "0.95",
+        "tix": "0.10"
       }
     },
     {
@@ -21713,7 +22653,9 @@
       "edhrec_rank": 4848,
       "properties": [],
       "prices": {
-        "usd": "0.57"
+        "usd": "0.57",
+        "eur": "0.34",
+        "tix": "0.03"
       }
     },
     {
@@ -21756,7 +22698,9 @@
       "edhrec_rank": 5800,
       "properties": [],
       "prices": {
-        "usd": "0.60"
+        "usd": "0.60",
+        "eur": "0.56",
+        "tix": "0.06"
       }
     },
     {
@@ -21800,7 +22744,9 @@
       "edhrec_rank": 741,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.15",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -21847,7 +22793,9 @@
       "edhrec_rank": 303,
       "properties": [],
       "prices": {
-        "usd": "0.47"
+        "usd": "0.47",
+        "eur": "0.25",
+        "tix": "0.03"
       }
     },
     {
@@ -21906,7 +22854,9 @@
       "edhrec_rank": 9480,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.30",
+        "tix": "0.25"
       }
     },
     {
@@ -21950,7 +22900,9 @@
       "edhrec_rank": 4333,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -22020,7 +22972,9 @@
       "edhrec_rank": 2699,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.43",
+        "tix": "0.03"
       }
     },
     {
@@ -22062,7 +23016,9 @@
       "edhrec_rank": 5056,
       "properties": [],
       "prices": {
-        "usd": "0.46"
+        "usd": "0.46",
+        "eur": "0.29",
+        "tix": "0.03"
       }
     },
     {
@@ -22132,7 +23088,9 @@
       "edhrec_rank": 2593,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.31",
+        "eur": "0.22",
+        "tix": "0.03"
       }
     },
     {
@@ -22175,7 +23133,9 @@
       "edhrec_rank": 201,
       "properties": [],
       "prices": {
-        "usd": "2.74"
+        "usd": "2.74",
+        "eur": "1.90",
+        "tix": "0.02"
       }
     },
     {
@@ -22218,7 +23178,9 @@
       "edhrec_rank": 5412,
       "properties": [],
       "prices": {
-        "usd": "1.53"
+        "usd": "1.53",
+        "eur": "0.42",
+        "tix": "0.04"
       }
     },
     {
@@ -22263,7 +23225,9 @@
       "edhrec_rank": 220,
       "properties": [],
       "prices": {
-        "usd": "31.34"
+        "usd": "31.34",
+        "eur": "24.85",
+        "tix": null
       }
     },
     {
@@ -22306,7 +23270,9 @@
       "edhrec_rank": 7050,
       "properties": [],
       "prices": {
-        "usd": "1.25"
+        "usd": "1.25",
+        "eur": "1.17",
+        "tix": "0.28"
       }
     },
     {
@@ -22380,7 +23346,9 @@
       "edhrec_rank": 8909,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.24",
+        "tix": "0.02"
       }
     },
     {
@@ -22424,7 +23392,9 @@
       "edhrec_rank": 5728,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.13",
+        "tix": "0.03"
       }
     },
     {
@@ -22494,7 +23464,9 @@
       "edhrec_rank": 1613,
       "properties": [],
       "prices": {
-        "usd": "0.54"
+        "usd": "0.54",
+        "eur": "0.69",
+        "tix": "0.03"
       }
     },
     {
@@ -22538,7 +23510,9 @@
       "edhrec_rank": 17053,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -22580,7 +23554,9 @@
       "edhrec_rank": 19270,
       "properties": [],
       "prices": {
-        "usd": "1.00"
+        "usd": "1.00",
+        "eur": "0.61",
+        "tix": "0.02"
       }
     },
     {
@@ -22624,7 +23600,9 @@
       "edhrec_rank": 385,
       "properties": [],
       "prices": {
-        "usd": "0.62"
+        "usd": "0.62",
+        "eur": "0.37",
+        "tix": "0.02"
       }
     },
     {
@@ -22673,7 +23651,9 @@
       "edhrec_rank": 356,
       "properties": [],
       "prices": {
-        "usd": "18.14"
+        "usd": "18.14",
+        "eur": "12.95",
+        "tix": "0.16"
       }
     },
     {
@@ -22745,7 +23725,9 @@
       "edhrec_rank": 1742,
       "properties": [],
       "prices": {
-        "usd": "0.44"
+        "usd": "0.44",
+        "eur": "0.34",
+        "tix": "0.03"
       }
     },
     {
@@ -22803,7 +23785,9 @@
       "edhrec_rank": 3061,
       "properties": [],
       "prices": {
-        "usd": "2.01"
+        "usd": "2.01",
+        "eur": "1.72",
+        "tix": "0.71"
       }
     },
     {
@@ -22862,7 +23846,9 @@
       "edhrec_rank": 1621,
       "properties": [],
       "prices": {
-        "usd": "0.60"
+        "usd": "0.60",
+        "eur": "0.22",
+        "tix": "0.02"
       }
     },
     {
@@ -22907,7 +23893,9 @@
       "edhrec_rank": 5145,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.16",
+        "tix": "0.02"
       }
     },
     {
@@ -22969,7 +23957,9 @@
       "edhrec_rank": 12443,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.24",
+        "tix": "0.02"
       }
     },
     {
@@ -23027,7 +24017,9 @@
       "edhrec_rank": 14522,
       "properties": [],
       "prices": {
-        "usd": "12.99"
+        "usd": "12.99",
+        "eur": "8.35",
+        "tix": null
       }
     },
     {
@@ -23069,7 +24061,9 @@
       "edhrec_rank": 3722,
       "properties": [],
       "prices": {
-        "usd": "18.94"
+        "usd": "18.94",
+        "eur": "11.48",
+        "tix": "9.17"
       }
     },
     {
@@ -23117,7 +24111,9 @@
       "edhrec_rank": 27464,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.25",
+        "tix": null
       }
     },
     {
@@ -23157,7 +24153,9 @@
       "edhrec_rank": 881,
       "properties": [],
       "prices": {
-        "usd": "0.51"
+        "usd": "0.51",
+        "eur": "0.45",
+        "tix": "0.04"
       }
     },
     {
@@ -23188,7 +24186,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.17",
+        "tix": "0.03"
       }
     },
     {
@@ -23245,7 +24245,9 @@
       "edhrec_rank": 4364,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.22",
+        "tix": "0.02"
       }
     },
     {
@@ -23287,7 +24289,9 @@
       "edhrec_rank": 2349,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.78",
+        "tix": "0.02"
       }
     },
     {
@@ -23329,7 +24333,9 @@
       "edhrec_rank": 5458,
       "properties": [],
       "prices": {
-        "usd": "124.65"
+        "usd": "124.65",
+        "eur": "80.18",
+        "tix": null
       }
     },
     {
@@ -23374,7 +24380,9 @@
       "edhrec_rank": 10008,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.13",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -23418,7 +24426,9 @@
       "edhrec_rank": 27679,
       "properties": [],
       "prices": {
-        "usd": "1.01"
+        "usd": "1.01",
+        "eur": "1.06",
+        "tix": null
       }
     },
     {
@@ -23463,7 +24473,9 @@
       "edhrec_rank": 22278,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.13",
+        "tix": "0.03"
       }
     },
     {
@@ -23507,7 +24519,9 @@
       "edhrec_rank": 27419,
       "properties": [],
       "prices": {
-        "usd": "1.01"
+        "usd": "1.01",
+        "eur": "0.93",
+        "tix": null
       }
     },
     {
@@ -23551,7 +24565,9 @@
       "edhrec_rank": 7449,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.46",
+        "tix": "0.02"
       }
     },
     {
@@ -23612,7 +24628,9 @@
       "edhrec_rank": 1914,
       "properties": [],
       "prices": {
-        "usd": "7.53"
+        "usd": "7.53",
+        "eur": "5.96",
+        "tix": "12.12"
       }
     },
     {
@@ -23654,7 +24672,9 @@
       "edhrec_rank": 2504,
       "properties": [],
       "prices": {
-        "usd": "1.29"
+        "usd": "1.29",
+        "eur": "0.62",
+        "tix": "0.03"
       }
     },
     {
@@ -23727,7 +24747,9 @@
       "edhrec_rank": 1209,
       "properties": [],
       "prices": {
-        "usd": "0.48"
+        "usd": "0.48",
+        "eur": "0.43",
+        "tix": "0.03"
       }
     },
     {
@@ -23789,7 +24811,9 @@
       "edhrec_rank": 13302,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.21",
+        "tix": "0.02"
       }
     },
     {
@@ -23834,7 +24858,9 @@
       "edhrec_rank": 3679,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -23913,7 +24939,9 @@
       "edhrec_rank": 1598,
       "properties": [],
       "prices": {
-        "usd": "2.35"
+        "usd": "2.35",
+        "eur": "1.94",
+        "tix": "0.02"
       }
     },
     {
@@ -23972,7 +25000,9 @@
       "edhrec_rank": 6801,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -24016,7 +25046,9 @@
       "edhrec_rank": 2251,
       "properties": [],
       "prices": {
-        "usd": "0.44"
+        "usd": "0.44",
+        "eur": "0.26",
+        "tix": "0.03"
       }
     },
     {
@@ -24061,7 +25093,9 @@
       "edhrec_rank": 137,
       "properties": [],
       "prices": {
-        "usd": "33.40"
+        "usd": "33.40",
+        "eur": "22.79",
+        "tix": "8.18"
       }
     },
     {
@@ -24106,7 +25140,9 @@
       "edhrec_rank": 6449,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.17",
+        "tix": "0.03"
       }
     },
     {
@@ -24150,7 +25186,9 @@
       "edhrec_rank": 1128,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.19",
+        "tix": "0.04"
       }
     },
     {
@@ -24192,7 +25230,9 @@
       "edhrec_rank": 11895,
       "properties": [],
       "prices": {
-        "usd": "0.08"
+        "usd": "0.08",
+        "eur": "0.17",
+        "tix": "0.03"
       }
     },
     {
@@ -24240,7 +25280,9 @@
       "edhrec_rank": 7383,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.16",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -24286,7 +25328,9 @@
       "edhrec_rank": 926,
       "properties": [],
       "prices": {
-        "usd": "4.40"
+        "usd": "4.40",
+        "eur": "3.48",
+        "tix": "0.19"
       }
     },
     {
@@ -24331,7 +25375,9 @@
       "edhrec_rank": 6913,
       "properties": [],
       "prices": {
-        "usd": "40.49"
+        "usd": "40.49",
+        "eur": "24.86",
+        "tix": "14.15"
       }
     },
     {
@@ -24393,7 +25439,9 @@
       "edhrec_rank": 16047,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.23",
+        "tix": "0.02"
       }
     },
     {
@@ -24437,7 +25485,9 @@
       "edhrec_rank": 4382,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.12",
+        "tix": "0.02"
       }
     },
     {
@@ -24480,7 +25530,9 @@
       "edhrec_rank": 4649,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.26",
+        "eur": "0.15",
+        "tix": "0.03"
       }
     },
     {
@@ -24525,7 +25577,9 @@
       "edhrec_rank": 4443,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.17",
+        "eur": "0.15",
+        "tix": "0.03"
       }
     },
     {
@@ -24571,7 +25625,9 @@
       "edhrec_rank": 709,
       "properties": [],
       "prices": {
-        "usd": "6.03"
+        "usd": "6.03",
+        "eur": "6.00",
+        "tix": "0.40"
       }
     },
     {
@@ -24616,7 +25672,9 @@
       "edhrec_rank": 163,
       "properties": [],
       "prices": {
-        "usd": "31.91"
+        "usd": "31.91",
+        "eur": "22.78",
+        "tix": "2.76"
       }
     },
     {
@@ -24658,7 +25716,9 @@
       "edhrec_rank": 13918,
       "properties": [],
       "prices": {
-        "usd": "0.50"
+        "usd": "0.50",
+        "eur": "0.25",
+        "tix": "0.03"
       }
     },
     {
@@ -24703,7 +25763,9 @@
       "edhrec_rank": 2223,
       "properties": [],
       "prices": {
-        "usd": "2.59"
+        "usd": "2.59",
+        "eur": "1.13",
+        "tix": "0.03"
       }
     },
     {
@@ -24742,7 +25804,9 @@
       "edhrec_rank": 1235,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.22",
+        "tix": "0.03"
       }
     },
     {
@@ -24782,7 +25846,9 @@
       "edhrec_rank": 4171,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.13",
+        "tix": "0.03"
       }
     },
     {
@@ -24824,7 +25890,9 @@
       "edhrec_rank": 13451,
       "properties": [],
       "prices": {
-        "usd": "1.10"
+        "usd": "1.10",
+        "eur": "0.75",
+        "tix": "0.02"
       }
     },
     {
@@ -24894,7 +25962,9 @@
       "edhrec_rank": 8441,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -24964,7 +26034,9 @@
       "edhrec_rank": 248,
       "properties": [],
       "prices": {
-        "usd": "13.94"
+        "usd": "13.94",
+        "eur": "10.14",
+        "tix": "0.03"
       }
     },
     {
@@ -25009,7 +26081,9 @@
       "edhrec_rank": 120,
       "properties": [],
       "prices": {
-        "usd": "33.52"
+        "usd": "33.52",
+        "eur": "22.22",
+        "tix": "0.83"
       }
     },
     {
@@ -25056,7 +26130,9 @@
       "edhrec_rank": 2257,
       "properties": [],
       "prices": {
-        "usd": "0.53"
+        "usd": "0.53",
+        "eur": "0.85",
+        "tix": "0.04"
       }
     },
     {
@@ -25112,7 +26188,9 @@
       "edhrec_rank": 5211,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.26",
+        "tix": "0.93"
       }
     },
     {
@@ -25149,7 +26227,9 @@
       "edhrec_rank": 50,
       "properties": [],
       "prices": {
-        "usd": "32.10"
+        "usd": "32.10",
+        "eur": "23.34",
+        "tix": "1.46"
       }
     },
     {
@@ -25186,7 +26266,9 @@
       "edhrec_rank": 524,
       "properties": [],
       "prices": {
-        "usd": "29.49"
+        "usd": "29.49",
+        "eur": "21.52",
+        "tix": null
       }
     },
     {
@@ -25226,7 +26308,9 @@
       "edhrec_rank": 23907,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.23",
+        "tix": "0.04"
       }
     },
     {
@@ -25266,7 +26350,9 @@
       "edhrec_rank": 2754,
       "properties": [],
       "prices": {
-        "usd": "1.55"
+        "usd": "1.55",
+        "eur": "2.34",
+        "tix": "0.02"
       }
     },
     {
@@ -25311,7 +26397,9 @@
       "edhrec_rank": 7439,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.12",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -25356,7 +26444,9 @@
       "edhrec_rank": 3263,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.31",
+        "tix": "0.03"
       }
     },
     {
@@ -25387,7 +26477,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -25429,7 +26521,9 @@
       "edhrec_rank": 2889,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.26",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -25471,7 +26565,9 @@
       "edhrec_rank": 9165,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.17",
+        "tix": "0.03"
       }
     },
     {
@@ -25529,7 +26625,9 @@
       "edhrec_rank": 6643,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.13",
+        "tix": "0.03"
       }
     },
     {
@@ -25571,7 +26669,9 @@
       "edhrec_rank": 12469,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.12",
+        "eur": "0.17",
+        "tix": "0.03"
       }
     },
     {
@@ -25613,7 +26713,9 @@
       "edhrec_rank": 13534,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.19",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -25655,7 +26757,9 @@
       "edhrec_rank": 20061,
       "properties": [],
       "prices": {
-        "usd": "0.56"
+        "usd": "0.56",
+        "eur": "0.30",
+        "tix": "0.12"
       }
     },
     {
@@ -25700,7 +26804,9 @@
       "edhrec_rank": 7499,
       "properties": [],
       "prices": {
-        "usd": "3.49"
+        "usd": "3.49",
+        "eur": "1.77",
+        "tix": "0.02"
       }
     },
     {
@@ -25746,7 +26852,9 @@
       "edhrec_rank": 704,
       "properties": [],
       "prices": {
-        "usd": "11.70"
+        "usd": "11.70",
+        "eur": "14.94",
+        "tix": "5.33"
       }
     },
     {
@@ -25809,7 +26917,9 @@
       "edhrec_rank": 1323,
       "properties": [],
       "prices": {
-        "usd": "2.49"
+        "usd": "2.49",
+        "eur": "1.96",
+        "tix": "0.02"
       }
     },
     {
@@ -25850,7 +26960,9 @@
       "edhrec_rank": 1156,
       "properties": [],
       "prices": {
-        "usd": "5.89"
+        "usd": "5.89",
+        "eur": "4.80",
+        "tix": "0.02"
       }
     },
     {
@@ -25893,7 +27005,9 @@
       "edhrec_rank": 601,
       "properties": [],
       "prices": {
-        "usd": "62.97"
+        "usd": "62.97",
+        "eur": "29.06",
+        "tix": "0.02"
       }
     },
     {
@@ -25935,7 +27049,9 @@
       "edhrec_rank": 2181,
       "properties": [],
       "prices": {
-        "usd": "18.86"
+        "usd": "18.86",
+        "eur": "12.00",
+        "tix": "2.57"
       }
     },
     {
@@ -25978,7 +27094,9 @@
       "edhrec_rank": 418,
       "properties": [],
       "prices": {
-        "usd": "6.05"
+        "usd": "6.05",
+        "eur": "4.51",
+        "tix": "0.02"
       }
     },
     {
@@ -26039,7 +27157,9 @@
       "edhrec_rank": 1040,
       "properties": [],
       "prices": {
-        "usd": "2.92"
+        "usd": "2.92",
+        "eur": "0.99",
+        "tix": "0.02"
       }
     },
     {
@@ -26084,7 +27204,9 @@
       "edhrec_rank": 3905,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.06",
+        "tix": "0.03"
       }
     },
     {
@@ -26124,7 +27246,9 @@
       "edhrec_rank": 8227,
       "properties": [],
       "prices": {
-        "usd": "20.29"
+        "usd": "20.29",
+        "eur": "8.12",
+        "tix": "0.02"
       }
     },
     {
@@ -26192,7 +27316,9 @@
       "edhrec_rank": 2694,
       "properties": [],
       "prices": {
-        "usd": "0.93"
+        "usd": "0.93",
+        "eur": "1.05",
+        "tix": "0.03"
       }
     },
     {
@@ -26237,7 +27363,9 @@
       "edhrec_rank": 10908,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.37",
+        "eur": "0.18",
+        "tix": "0.03"
       }
     },
     {
@@ -26293,7 +27421,9 @@
       "edhrec_rank": 2748,
       "properties": [],
       "prices": {
-        "usd": "1.97"
+        "usd": "1.97",
+        "eur": "2.28",
+        "tix": "0.02"
       }
     },
     {
@@ -26334,7 +27464,9 @@
       "edhrec_rank": 3045,
       "properties": [],
       "prices": {
-        "usd": "84.56"
+        "usd": "84.56",
+        "eur": "78.97",
+        "tix": null
       }
     },
     {
@@ -26390,7 +27522,9 @@
       "edhrec_rank": 7345,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.36",
+        "tix": "0.02"
       }
     },
     {
@@ -26431,7 +27565,9 @@
       "edhrec_rank": 4111,
       "properties": [],
       "prices": {
-        "usd": "3000.48"
+        "usd": "3000.48",
+        "eur": "3204.70",
+        "tix": null
       }
     },
     {
@@ -26475,7 +27611,9 @@
       "edhrec_rank": 437,
       "properties": [],
       "prices": {
-        "usd": "9.62"
+        "usd": "9.62",
+        "eur": "6.96",
+        "tix": "0.90"
       }
     },
     {
@@ -26522,7 +27660,9 @@
       "edhrec_rank": 1741,
       "properties": [],
       "prices": {
-        "usd": "0.60"
+        "usd": "0.60",
+        "eur": "0.45",
+        "tix": "0.03"
       }
     },
     {
@@ -26564,7 +27704,9 @@
       "edhrec_rank": 2951,
       "properties": [],
       "prices": {
-        "usd": "1.30"
+        "usd": "1.30",
+        "eur": "0.60",
+        "tix": "0.03"
       }
     },
     {
@@ -26595,7 +27737,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.19",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -26632,7 +27776,9 @@
       "edhrec_rank": 40,
       "properties": [],
       "prices": {
-        "usd": "37.83"
+        "usd": "37.83",
+        "eur": "24.27",
+        "tix": "2.79"
       }
     },
     {
@@ -26673,7 +27819,9 @@
       "edhrec_rank": 8925,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.16",
+        "eur": "0.12",
+        "tix": "0.02"
       }
     },
     {
@@ -26718,7 +27866,9 @@
       "edhrec_rank": 24867,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.27",
+        "tix": "0.04"
       }
     },
     {
@@ -26763,7 +27913,9 @@
       "edhrec_rank": 8273,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.12",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -26808,7 +27960,9 @@
       "edhrec_rank": 2489,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.37",
+        "eur": "0.25",
+        "tix": "0.03"
       }
     },
     {
@@ -26850,7 +28004,9 @@
       "edhrec_rank": 1471,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.39",
+        "eur": "0.55",
+        "tix": "0.02"
       }
     },
     {
@@ -26892,7 +28048,9 @@
       "edhrec_rank": 11573,
       "properties": [],
       "prices": {
-        "usd": "0.45"
+        "usd": "0.45",
+        "eur": "0.22",
+        "tix": "0.03"
       }
     },
     {
@@ -26951,7 +28109,9 @@
       "edhrec_rank": 8426,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.21",
+        "tix": "0.02"
       }
     },
     {
@@ -26996,7 +28156,9 @@
       "edhrec_rank": 139,
       "properties": [],
       "prices": {
-        "usd": "30.36"
+        "usd": "30.36",
+        "eur": "23.72",
+        "tix": "3.76"
       }
     },
     {
@@ -27038,7 +28200,9 @@
       "edhrec_rank": 651,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.24",
+        "tix": "0.03"
       }
     },
     {
@@ -27083,7 +28247,9 @@
       "edhrec_rank": 522,
       "properties": [],
       "prices": {
-        "usd": "2.38"
+        "usd": "2.38",
+        "eur": "2.86",
+        "tix": "1.29"
       }
     },
     {
@@ -27127,7 +28293,9 @@
       "edhrec_rank": 192,
       "properties": [],
       "prices": {
-        "usd": "2.44"
+        "usd": "2.44",
+        "eur": "0.84",
+        "tix": "0.03"
       }
     },
     {
@@ -27171,7 +28339,9 @@
       "edhrec_rank": 1195,
       "properties": [],
       "prices": {
-        "usd": "7.94"
+        "usd": "7.94",
+        "eur": "5.54",
+        "tix": "0.02"
       }
     },
     {
@@ -27208,7 +28378,9 @@
       "edhrec_rank": 23925,
       "properties": [],
       "prices": {
-        "usd": "7.17"
+        "usd": "7.17",
+        "eur": "5.20",
+        "tix": null
       }
     },
     {
@@ -27245,7 +28417,9 @@
       "edhrec_rank": 3120,
       "properties": [],
       "prices": {
-        "usd": "2.16"
+        "usd": "2.16",
+        "eur": "0.69",
+        "tix": "0.04"
       }
     },
     {
@@ -27285,7 +28459,9 @@
       "edhrec_rank": 10444,
       "properties": [],
       "prices": {
-        "usd": "0.59"
+        "usd": "0.59",
+        "eur": "0.64",
+        "tix": "0.03"
       }
     },
     {
@@ -27328,7 +28504,9 @@
       "edhrec_rank": 2724,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -27352,7 +28530,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "9.16"
+        "usd": "9.16",
+        "eur": "12.20",
+        "tix": null
       }
     },
     {
@@ -27412,7 +28592,9 @@
       "edhrec_rank": 1597,
       "properties": [],
       "prices": {
-        "usd": "1.03"
+        "usd": "1.03",
+        "eur": "0.81",
+        "tix": "0.02"
       }
     },
     {
@@ -27457,7 +28639,9 @@
       "edhrec_rank": 8714,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.18",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -27503,7 +28687,9 @@
       "edhrec_rank": 2605,
       "properties": [],
       "prices": {
-        "usd": "1.65"
+        "usd": "1.65",
+        "eur": "0.77",
+        "tix": "0.02"
       }
     },
     {
@@ -27534,7 +28720,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.10",
+        "eur": "0.07",
+        "tix": "0.01"
       }
     },
     {
@@ -27575,7 +28763,9 @@
       "edhrec_rank": 1894,
       "properties": [],
       "prices": {
-        "usd": "8.83"
+        "usd": "8.83",
+        "eur": "6.13",
+        "tix": "0.26"
       }
     },
     {
@@ -27615,7 +28805,9 @@
       "edhrec_rank": 27,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.26",
+        "eur": "0.39",
+        "tix": "0.09"
       }
     },
     {
@@ -27661,7 +28853,9 @@
       "edhrec_rank": 897,
       "properties": [],
       "prices": {
-        "usd": "7.36"
+        "usd": "7.36",
+        "eur": "3.69",
+        "tix": "0.02"
       }
     },
     {
@@ -27709,7 +28903,9 @@
       "edhrec_rank": 379,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.26",
+        "eur": "0.21",
+        "tix": "0.03"
       }
     },
     {
@@ -27751,7 +28947,9 @@
       "edhrec_rank": 172,
       "properties": [],
       "prices": {
-        "usd": "1.37"
+        "usd": "1.37",
+        "eur": "1.17",
+        "tix": "0.03"
       }
     },
     {
@@ -27791,7 +28989,9 @@
       "edhrec_rank": 6944,
       "properties": [],
       "prices": {
-        "usd": "0.62"
+        "usd": "0.62",
+        "eur": "0.59",
+        "tix": "0.02"
       }
     },
     {
@@ -27836,7 +29036,9 @@
       "edhrec_rank": 18545,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.33",
+        "tix": "0.04"
       }
     },
     {
@@ -27877,7 +29079,9 @@
       "edhrec_rank": 4196,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.19",
+        "tix": "0.03"
       }
     },
     {
@@ -27923,7 +29127,9 @@
       "edhrec_rank": 533,
       "properties": [],
       "prices": {
-        "usd": "0.63"
+        "usd": "0.63",
+        "eur": "0.70",
+        "tix": "0.02"
       }
     },
     {
@@ -27967,7 +29173,9 @@
       "edhrec_rank": 5177,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.26",
+        "tix": "0.02"
       }
     },
     {
@@ -28037,7 +29245,9 @@
       "edhrec_rank": 843,
       "properties": [],
       "prices": {
-        "usd": "5.28"
+        "usd": "5.28",
+        "eur": "3.99",
+        "tix": "0.06"
       }
     },
     {
@@ -28082,7 +29292,9 @@
       "edhrec_rank": 8192,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.15",
+        "eur": "0.05",
+        "tix": "0.03"
       }
     },
     {
@@ -28123,7 +29335,9 @@
       "edhrec_rank": 9664,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.18",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -28169,7 +29383,9 @@
       "edhrec_rank": 3173,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.37",
+        "tix": "0.02"
       }
     },
     {
@@ -28210,7 +29426,9 @@
       "edhrec_rank": 563,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.31",
+        "eur": "0.35",
+        "tix": "0.90"
       }
     },
     {
@@ -28254,7 +29472,9 @@
       "edhrec_rank": 9343,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.15",
+        "tix": "0.03"
       }
     },
     {
@@ -28301,7 +29521,9 @@
       "edhrec_rank": 6914,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.10",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -28347,7 +29569,9 @@
       "edhrec_rank": 1849,
       "properties": [],
       "prices": {
-        "usd": "8.56"
+        "usd": "8.56",
+        "eur": "4.79",
+        "tix": "0.02"
       }
     },
     {
@@ -28392,7 +29616,9 @@
       "edhrec_rank": 18668,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.13",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -28440,7 +29666,9 @@
       "edhrec_rank": 358,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.17",
+        "tix": "0.03"
       }
     },
     {
@@ -28484,7 +29712,9 @@
       "edhrec_rank": 13991,
       "properties": [],
       "prices": {
-        "usd": "0.48"
+        "usd": "0.48",
+        "eur": "0.41",
+        "tix": "0.04"
       }
     },
     {
@@ -28515,7 +29745,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -28542,7 +29774,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.24",
+        "tix": "0.03"
       }
     },
     {
@@ -28587,7 +29821,9 @@
       "edhrec_rank": 6982,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.39",
+        "eur": "0.25",
+        "tix": "0.03"
       }
     },
     {
@@ -28632,7 +29868,9 @@
       "edhrec_rank": 1544,
       "properties": [],
       "prices": {
-        "usd": "6.94"
+        "usd": "6.94",
+        "eur": "5.63",
+        "tix": "1.24"
       }
     },
     {
@@ -28677,7 +29915,9 @@
       "edhrec_rank": 170,
       "properties": [],
       "prices": {
-        "usd": "51.74"
+        "usd": "51.74",
+        "eur": "33.30",
+        "tix": "0.14"
       }
     },
     {
@@ -28720,7 +29960,9 @@
       "edhrec_rank": 2998,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.36",
+        "tix": "0.03"
       }
     },
     {
@@ -28757,7 +29999,9 @@
       "edhrec_rank": 21144,
       "properties": [],
       "prices": {
-        "usd": "36.73"
+        "usd": "36.73",
+        "eur": "20.63",
+        "tix": null
       }
     },
     {
@@ -28800,7 +30044,9 @@
       "edhrec_rank": 5068,
       "properties": [],
       "prices": {
-        "usd": "21.99"
+        "usd": "21.99",
+        "eur": "15.20",
+        "tix": "0.02"
       }
     },
     {
@@ -28839,7 +30085,9 @@
       "edhrec_rank": 1562,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.35",
+        "tix": "0.03"
       }
     },
     {
@@ -28882,7 +30130,9 @@
       "edhrec_rank": 6220,
       "properties": [],
       "prices": {
-        "usd": "4.50"
+        "usd": "4.50",
+        "eur": "3.98",
+        "tix": "0.02"
       }
     },
     {
@@ -28913,7 +30163,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -28946,7 +30198,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.12",
+        "tix": null
       }
     },
     {
@@ -28987,7 +30241,9 @@
       "edhrec_rank": 5818,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.28",
+        "tix": null
       }
     },
     {
@@ -29057,7 +30313,9 @@
       "edhrec_rank": 2145,
       "properties": [],
       "prices": {
-        "usd": "1.25"
+        "usd": "1.25",
+        "eur": "0.83",
+        "tix": "0.02"
       }
     },
     {
@@ -29102,7 +30360,9 @@
       "edhrec_rank": 633,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.20",
+        "tix": "0.04"
       }
     },
     {
@@ -29150,7 +30410,9 @@
       "edhrec_rank": 375,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -29192,7 +30454,9 @@
       "edhrec_rank": 733,
       "properties": [],
       "prices": {
-        "usd": "1.32"
+        "usd": "1.32",
+        "eur": "1.18",
+        "tix": "0.02"
       }
     },
     {
@@ -29237,7 +30501,9 @@
       "edhrec_rank": 378,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -29283,7 +30549,9 @@
       "edhrec_rank": 1848,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -29328,7 +30596,9 @@
       "edhrec_rank": 17324,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -29363,7 +30633,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.51"
+        "usd": "0.51",
+        "eur": "0.51",
+        "tix": null
       }
     },
     {
@@ -29407,7 +30679,9 @@
       "edhrec_rank": 90,
       "properties": [],
       "prices": {
-        "usd": "32.25"
+        "usd": "32.25",
+        "eur": "21.10",
+        "tix": "2.45"
       }
     },
     {
@@ -29452,7 +30726,9 @@
       "edhrec_rank": 715,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.39",
+        "tix": "0.08"
       }
     },
     {
@@ -29497,7 +30773,9 @@
       "edhrec_rank": 290,
       "properties": [],
       "prices": {
-        "usd": "2.82"
+        "usd": "2.82",
+        "eur": "2.59",
+        "tix": "0.02"
       }
     },
     {
@@ -29542,7 +30820,9 @@
       "edhrec_rank": 70,
       "properties": [],
       "prices": {
-        "usd": "18.28"
+        "usd": "18.28",
+        "eur": "9.42",
+        "tix": "0.03"
       }
     },
     {
@@ -29588,7 +30868,9 @@
       "edhrec_rank": 6685,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.12",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -29633,7 +30915,9 @@
       "edhrec_rank": 24275,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.56",
+        "tix": null
       }
     },
     {
@@ -29666,7 +30950,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.18",
+        "eur": "0.09",
+        "tix": "0.01"
       }
     },
     {
@@ -29712,7 +30998,9 @@
       "edhrec_rank": 14,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.29",
+        "tix": "0.01"
       }
     },
     {
@@ -29754,7 +31042,9 @@
       "edhrec_rank": 6634,
       "properties": [],
       "prices": {
-        "usd": "3.27"
+        "usd": "3.27",
+        "eur": "1.67",
+        "tix": "4.87"
       }
     },
     {
@@ -29799,7 +31089,9 @@
       "edhrec_rank": 8575,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.18",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -29869,7 +31161,9 @@
       "edhrec_rank": 9377,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -29912,7 +31206,9 @@
       "edhrec_rank": 8103,
       "properties": [],
       "prices": {
-        "usd": "18.30"
+        "usd": "18.30",
+        "eur": "25.49",
+        "tix": null
       }
     },
     {
@@ -29958,7 +31254,9 @@
       "edhrec_rank": 2011,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.15",
+        "tix": "0.03"
       }
     },
     {
@@ -29998,7 +31296,9 @@
       "edhrec_rank": 7621,
       "properties": [],
       "prices": {
-        "usd": "4.65"
+        "usd": "4.65",
+        "eur": "3.90",
+        "tix": "0.26"
       }
     },
     {
@@ -30025,7 +31325,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.51"
+        "usd": "0.51",
+        "eur": "1.27",
+        "tix": "0.35"
       }
     },
     {
@@ -30067,7 +31369,9 @@
       "edhrec_rank": 6435,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -30111,7 +31415,9 @@
       "edhrec_rank": 198,
       "properties": [],
       "prices": {
-        "usd": "48.79"
+        "usd": "48.79",
+        "eur": "34.28",
+        "tix": "6.37"
       }
     },
     {
@@ -30156,7 +31462,9 @@
       "edhrec_rank": 6319,
       "properties": [],
       "prices": {
-        "usd": "1.27"
+        "usd": "1.27",
+        "eur": "1.42",
+        "tix": "0.02"
       }
     },
     {
@@ -30201,7 +31509,9 @@
       "edhrec_rank": 20746,
       "properties": [],
       "prices": {
-        "usd": "1.72"
+        "usd": "1.72",
+        "eur": "1.25",
+        "tix": "0.23"
       }
     },
     {
@@ -30246,7 +31556,9 @@
       "edhrec_rank": 23946,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.21",
+        "eur": "0.09",
+        "tix": "0.04"
       }
     },
     {
@@ -30320,7 +31632,9 @@
       "edhrec_rank": 542,
       "properties": [],
       "prices": {
-        "usd": "1.41"
+        "usd": "1.41",
+        "eur": "1.76",
+        "tix": "0.03"
       }
     },
     {
@@ -30362,7 +31676,9 @@
       "edhrec_rank": 11564,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.20",
+        "tix": "0.03"
       }
     },
     {
@@ -30407,7 +31723,9 @@
       "edhrec_rank": 3349,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.24",
+        "tix": "0.03"
       }
     },
     {
@@ -30453,7 +31771,9 @@
       "edhrec_rank": 2587,
       "properties": [],
       "prices": {
-        "usd": "10.32"
+        "usd": "10.32",
+        "eur": "7.58",
+        "tix": "10.83"
       }
     },
     {
@@ -30497,7 +31817,9 @@
       "edhrec_rank": 456,
       "properties": [],
       "prices": {
-        "usd": "2479.99"
+        "usd": "2479.99",
+        "eur": "3389.09",
+        "tix": null
       }
     },
     {
@@ -30542,7 +31864,9 @@
       "edhrec_rank": 7288,
       "properties": [],
       "prices": {
-        "usd": "0.51"
+        "usd": "0.51",
+        "eur": "0.52",
+        "tix": "0.02"
       }
     },
     {
@@ -30587,7 +31911,9 @@
       "edhrec_rank": 529,
       "properties": [],
       "prices": {
-        "usd": "8.82"
+        "usd": "8.82",
+        "eur": "6.69",
+        "tix": "0.03"
       }
     },
     {
@@ -30624,7 +31950,9 @@
       "edhrec_rank": 37,
       "properties": [],
       "prices": {
-        "usd": "124.65"
+        "usd": "124.65",
+        "eur": "70.02",
+        "tix": "16.40"
       }
     },
     {
@@ -30668,7 +31996,9 @@
       "edhrec_rank": 4000,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.22",
+        "tix": "0.04"
       }
     },
     {
@@ -30713,7 +32043,9 @@
       "edhrec_rank": 3779,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.18",
+        "tix": "0.03"
       }
     },
     {
@@ -30758,7 +32090,9 @@
       "edhrec_rank": 345,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.48",
+        "tix": "0.02"
       }
     },
     {
@@ -30805,7 +32139,9 @@
       "edhrec_rank": 2004,
       "properties": [],
       "prices": {
-        "usd": "0.42"
+        "usd": "0.42",
+        "eur": "0.29",
+        "tix": "0.03"
       }
     },
     {
@@ -30850,7 +32186,9 @@
       "edhrec_rank": 17413,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.15",
+        "tix": "0.03"
       }
     },
     {
@@ -30895,7 +32233,9 @@
       "edhrec_rank": 106,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.31",
+        "eur": "0.24",
+        "tix": "0.02"
       }
     },
     {
@@ -30940,7 +32280,9 @@
       "edhrec_rank": 6588,
       "properties": [],
       "prices": {
-        "usd": "2.85"
+        "usd": "2.85",
+        "eur": "1.47",
+        "tix": "0.02"
       }
     },
     {
@@ -30988,7 +32330,9 @@
       "edhrec_rank": 5638,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -31026,7 +32370,9 @@
       "edhrec_rank": 195,
       "properties": [],
       "prices": {
-        "usd": "37.76"
+        "usd": "37.76",
+        "eur": "33.42",
+        "tix": "3.98"
       }
     },
     {
@@ -31067,7 +32413,9 @@
       "edhrec_rank": 2976,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -31111,7 +32459,9 @@
       "edhrec_rank": 8556,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.13",
+        "tix": "0.03"
       }
     },
     {
@@ -31159,7 +32509,9 @@
       "edhrec_rank": 4682,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.18",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -31199,7 +32551,9 @@
       "edhrec_rank": 15540,
       "properties": [],
       "prices": {
-        "usd": "0.44"
+        "usd": "0.44",
+        "eur": "0.53",
+        "tix": "0.38"
       }
     },
     {
@@ -31244,7 +32598,9 @@
       "edhrec_rank": 5082,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.17",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -31289,7 +32645,9 @@
       "edhrec_rank": 7684,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.13",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -31330,7 +32688,9 @@
       "edhrec_rank": 1600,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.22",
+        "tix": "0.03"
       }
     },
     {
@@ -31375,7 +32735,9 @@
       "edhrec_rank": 1473,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -31419,7 +32781,9 @@
       "edhrec_rank": 1612,
       "properties": [],
       "prices": {
-        "usd": "1.04"
+        "usd": "1.04",
+        "eur": "1.06",
+        "tix": "1.63"
       }
     },
     {
@@ -31469,7 +32833,9 @@
       "edhrec_rank": 417,
       "properties": [],
       "prices": {
-        "usd": "13.96"
+        "usd": "13.96",
+        "eur": "12.39",
+        "tix": "0.17"
       }
     },
     {
@@ -31513,7 +32879,9 @@
       "edhrec_rank": 2653,
       "properties": [],
       "prices": {
-        "usd": "0.47"
+        "usd": "0.47",
+        "eur": "0.42",
+        "tix": "0.02"
       }
     },
     {
@@ -31546,7 +32914,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.30",
+        "tix": "1.03"
       }
     },
     {
@@ -31591,7 +32961,9 @@
       "edhrec_rank": 13132,
       "properties": [],
       "prices": {
-        "usd": "10.12"
+        "usd": "10.12",
+        "eur": "5.36",
+        "tix": null
       }
     },
     {
@@ -31636,7 +33008,9 @@
       "edhrec_rank": 476,
       "properties": [],
       "prices": {
-        "usd": "1.09"
+        "usd": "1.09",
+        "eur": "0.21",
+        "tix": "0.03"
       }
     },
     {
@@ -31682,7 +33056,9 @@
       "edhrec_rank": 1908,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -31725,7 +33101,9 @@
       "edhrec_rank": 3676,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.28",
+        "tix": "0.04"
       }
     },
     {
@@ -31765,7 +33143,9 @@
       "edhrec_rank": 17136,
       "properties": [],
       "prices": {
-        "usd": "0.81"
+        "usd": "0.81",
+        "eur": "0.56",
+        "tix": "0.31"
       }
     },
     {
@@ -31810,7 +33190,9 @@
       "edhrec_rank": 8396,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -31856,7 +33238,9 @@
       "edhrec_rank": 562,
       "properties": [],
       "prices": {
-        "usd": "11.49"
+        "usd": "11.49",
+        "eur": "9.77",
+        "tix": "1.41"
       }
     },
     {
@@ -31905,7 +33289,9 @@
       "edhrec_rank": 493,
       "properties": [],
       "prices": {
-        "usd": "16.42"
+        "usd": "16.42",
+        "eur": "12.61",
+        "tix": "0.11"
       }
     },
     {
@@ -31951,7 +33337,9 @@
       "edhrec_rank": 24174,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.21",
+        "eur": "0.10",
+        "tix": "0.04"
       }
     },
     {
@@ -32021,7 +33409,9 @@
       "edhrec_rank": 1857,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.32",
+        "tix": "0.03"
       }
     },
     {
@@ -32068,7 +33458,9 @@
       "edhrec_rank": 1034,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.21",
+        "tix": "0.03"
       }
     },
     {
@@ -32113,7 +33505,9 @@
       "edhrec_rank": 8124,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -32159,7 +33553,9 @@
       "edhrec_rank": 1476,
       "properties": [],
       "prices": {
-        "usd": "1.01"
+        "usd": "1.01",
+        "eur": "0.86",
+        "tix": "0.02"
       }
     },
     {
@@ -32188,7 +33584,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.40",
+        "tix": "0.02"
       }
     },
     {
@@ -32246,7 +33644,9 @@
       "edhrec_rank": 11899,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.12",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -32291,7 +33691,9 @@
       "edhrec_rank": 173,
       "properties": [],
       "prices": {
-        "usd": "44.02"
+        "usd": "44.02",
+        "eur": "34.57",
+        "tix": "23.38"
       }
     },
     {
@@ -32336,7 +33738,9 @@
       "edhrec_rank": 143,
       "properties": [],
       "prices": {
-        "usd": "8.40"
+        "usd": "8.40",
+        "eur": "7.40",
+        "tix": "6.46"
       }
     },
     {
@@ -32377,7 +33781,9 @@
       "edhrec_rank": 10,
       "properties": [],
       "prices": {
-        "usd": "4.75"
+        "usd": "4.75",
+        "eur": "1.44",
+        "tix": "0.03"
       }
     },
     {
@@ -32419,7 +33825,9 @@
       "edhrec_rank": 9756,
       "properties": [],
       "prices": {
-        "usd": "0.85"
+        "usd": "0.85",
+        "eur": "0.85",
+        "tix": "2.95"
       }
     },
     {
@@ -32463,7 +33871,9 @@
       "edhrec_rank": 4156,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.37",
+        "eur": "0.44",
+        "tix": "0.05"
       }
     },
     {
@@ -32523,7 +33933,9 @@
       "edhrec_rank": 3800,
       "properties": [],
       "prices": {
-        "usd": "1.20"
+        "usd": "1.20",
+        "eur": "1.08",
+        "tix": "0.02"
       }
     },
     {
@@ -32567,7 +33979,9 @@
       "edhrec_rank": 4244,
       "properties": [],
       "prices": {
-        "usd": "0.49"
+        "usd": "0.49",
+        "eur": "0.44",
+        "tix": "0.02"
       }
     },
     {
@@ -32629,7 +34043,9 @@
       "edhrec_rank": 3077,
       "properties": [],
       "prices": {
-        "usd": "2.34"
+        "usd": "2.34",
+        "eur": "1.36",
+        "tix": "0.02"
       }
     },
     {
@@ -32673,7 +34089,9 @@
       "edhrec_rank": 4234,
       "properties": [],
       "prices": {
-        "usd": "0.74"
+        "usd": "0.74",
+        "eur": "0.60",
+        "tix": "0.02"
       }
     },
     {
@@ -32717,7 +34135,9 @@
       "edhrec_rank": 5098,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.26",
+        "tix": "0.03"
       }
     },
     {
@@ -32763,7 +34183,9 @@
       "edhrec_rank": 3721,
       "properties": [],
       "prices": {
-        "usd": "2.62"
+        "usd": "2.62",
+        "eur": "1.60",
+        "tix": "0.12"
       }
     },
     {
@@ -32807,7 +34229,9 @@
       "edhrec_rank": 4324,
       "properties": [],
       "prices": {
-        "usd": "0.46"
+        "usd": "0.46",
+        "eur": "0.37",
+        "tix": "0.02"
       }
     },
     {
@@ -32853,7 +34277,9 @@
       "edhrec_rank": 4727,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.31",
+        "eur": "0.25",
+        "tix": "0.02"
       }
     },
     {
@@ -32895,7 +34321,9 @@
       "edhrec_rank": 4766,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.41",
+        "eur": "0.24",
+        "tix": "0.03"
       }
     },
     {
@@ -32939,7 +34367,9 @@
       "edhrec_rank": 5174,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.43",
+        "tix": "0.02"
       }
     },
     {
@@ -33012,7 +34442,9 @@
       "edhrec_rank": 738,
       "properties": [],
       "prices": {
-        "usd": "0.93"
+        "usd": "0.93",
+        "eur": "1.30",
+        "tix": "0.03"
       }
     },
     {
@@ -33057,7 +34489,9 @@
       "edhrec_rank": 19711,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.31",
+        "tix": "0.05"
       }
     },
     {
@@ -33102,7 +34536,9 @@
       "edhrec_rank": 10928,
       "properties": [],
       "prices": {
-        "usd": "2.68"
+        "usd": "2.68",
+        "eur": "1.63",
+        "tix": "0.04"
       }
     },
     {
@@ -33147,7 +34583,9 @@
       "edhrec_rank": 2486,
       "properties": [],
       "prices": {
-        "usd": "0.52"
+        "usd": "0.52",
+        "eur": "0.67",
+        "tix": "0.03"
       }
     },
     {
@@ -33189,7 +34627,9 @@
       "edhrec_rank": 1749,
       "properties": [],
       "prices": {
-        "usd": "2.46"
+        "usd": "2.46",
+        "eur": "1.31",
+        "tix": "0.02"
       }
     },
     {
@@ -33230,7 +34670,9 @@
       "edhrec_rank": 14393,
       "properties": [],
       "prices": {
-        "usd": "93.62"
+        "usd": "93.62",
+        "eur": "88.51",
+        "tix": "29.36"
       }
     },
     {
@@ -33276,7 +34718,9 @@
       "edhrec_rank": 9015,
       "properties": [],
       "prices": {
-        "usd": "0.57"
+        "usd": "0.57",
+        "eur": "0.63",
+        "tix": "0.18"
       }
     },
     {
@@ -33321,7 +34765,9 @@
       "edhrec_rank": 998,
       "properties": [],
       "prices": {
-        "usd": "1.35"
+        "usd": "1.35",
+        "eur": "1.23",
+        "tix": "0.02"
       }
     },
     {
@@ -33365,7 +34811,9 @@
       "edhrec_rank": 26532,
       "properties": [],
       "prices": {
-        "usd": "1.00"
+        "usd": "1.00",
+        "eur": "1.44",
+        "tix": null
       }
     },
     {
@@ -33408,7 +34856,9 @@
       "edhrec_rank": 2558,
       "properties": [],
       "prices": {
-        "usd": "1.63"
+        "usd": "1.63",
+        "eur": "0.92",
+        "tix": "0.02"
       }
     },
     {
@@ -33478,7 +34928,9 @@
       "edhrec_rank": 846,
       "properties": [],
       "prices": {
-        "usd": "5.77"
+        "usd": "5.77",
+        "eur": "4.83",
+        "tix": "0.09"
       }
     },
     {
@@ -33523,7 +34975,9 @@
       "edhrec_rank": 1021,
       "properties": [],
       "prices": {
-        "usd": "23.51"
+        "usd": "23.51",
+        "eur": "19.77",
+        "tix": "1.34"
       }
     },
     {
@@ -33562,7 +35016,9 @@
       "edhrec_rank": 708,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.28",
+        "tix": "0.03"
       }
     },
     {
@@ -33607,7 +35063,9 @@
       "edhrec_rank": 9492,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.19",
+        "tix": "0.03"
       }
     },
     {
@@ -33648,7 +35106,9 @@
       "edhrec_rank": 3612,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.27",
+        "tix": "0.03"
       }
     },
     {
@@ -33691,7 +35151,9 @@
       "edhrec_rank": 5621,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.17",
+        "tix": "0.03"
       }
     },
     {
@@ -33736,7 +35198,9 @@
       "edhrec_rank": 216,
       "properties": [],
       "prices": {
-        "usd": "2.54"
+        "usd": "2.54",
+        "eur": "1.59",
+        "tix": "0.03"
       }
     },
     {
@@ -33794,7 +35258,9 @@
       "edhrec_rank": 10828,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -33831,7 +35297,9 @@
       "edhrec_rank": 3375,
       "properties": [],
       "prices": {
-        "usd": "0.62"
+        "usd": "0.62",
+        "eur": "0.75",
+        "tix": "0.04"
       }
     },
     {
@@ -33872,7 +35340,9 @@
       "edhrec_rank": 19,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.41",
+        "tix": "0.03"
       }
     },
     {
@@ -33916,7 +35386,9 @@
       "edhrec_rank": 129,
       "properties": [],
       "prices": {
-        "usd": "1.84"
+        "usd": "1.84",
+        "eur": "1.01",
+        "tix": "0.02"
       }
     },
     {
@@ -33961,7 +35433,9 @@
       "edhrec_rank": 23390,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.25",
+        "tix": "0.04"
       }
     },
     {
@@ -34005,7 +35479,9 @@
       "edhrec_rank": 1352,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.16",
+        "eur": "0.06",
+        "tix": "0.03"
       }
     },
     {
@@ -34051,7 +35527,9 @@
       "edhrec_rank": 296,
       "properties": [],
       "prices": {
-        "usd": "4.85"
+        "usd": "4.85",
+        "eur": "1.74",
+        "tix": "0.02"
       }
     },
     {
@@ -34091,7 +35569,9 @@
       "edhrec_rank": 5845,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.18",
+        "tix": "0.02"
       }
     },
     {
@@ -34133,7 +35613,9 @@
       "edhrec_rank": 16465,
       "properties": [],
       "prices": {
-        "usd": "0.49"
+        "usd": "0.49",
+        "eur": "0.67",
+        "tix": null
       }
     },
     {
@@ -34168,7 +35650,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.26",
+        "eur": "0.17",
+        "tix": "0.03"
       }
     },
     {
@@ -34212,7 +35696,9 @@
       "edhrec_rank": 5962,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.12",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -34301,7 +35787,9 @@
       "edhrec_rank": 4956,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.20",
+        "tix": "0.03"
       }
     },
     {
@@ -34343,7 +35831,9 @@
       "edhrec_rank": 18478,
       "properties": [],
       "prices": {
-        "usd": "0.56"
+        "usd": "0.56",
+        "eur": "0.44",
+        "tix": "0.04"
       }
     },
     {
@@ -34387,7 +35877,9 @@
       "edhrec_rank": 20570,
       "properties": [],
       "prices": {
-        "usd": "0.43"
+        "usd": "0.43",
+        "eur": "0.31",
+        "tix": "0.02"
       }
     },
     {
@@ -34434,7 +35926,9 @@
       "edhrec_rank": 1214,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.21",
+        "tix": "0.03"
       }
     },
     {
@@ -34479,7 +35973,9 @@
       "edhrec_rank": 78,
       "properties": [],
       "prices": {
-        "usd": "17.52"
+        "usd": "17.52",
+        "eur": "9.45",
+        "tix": "0.20"
       }
     },
     {
@@ -34524,7 +36020,9 @@
       "edhrec_rank": 1716,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.13",
+        "tix": "0.03"
       }
     },
     {
@@ -34561,7 +36059,9 @@
       "edhrec_rank": 17993,
       "properties": [],
       "prices": {
-        "usd": "5.62"
+        "usd": "5.62",
+        "eur": "6.48",
+        "tix": null
       }
     },
     {
@@ -34606,7 +36106,9 @@
       "edhrec_rank": 20056,
       "properties": [],
       "prices": {
-        "usd": "1.58"
+        "usd": "1.58",
+        "eur": "1.44",
+        "tix": "0.26"
       }
     },
     {
@@ -34651,7 +36153,9 @@
       "edhrec_rank": 11198,
       "properties": [],
       "prices": {
-        "usd": "0.61"
+        "usd": "0.61",
+        "eur": "0.64",
+        "tix": "0.10"
       }
     },
     {
@@ -34696,7 +36200,9 @@
       "edhrec_rank": 12096,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.12",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -34737,7 +36243,9 @@
       "edhrec_rank": 3627,
       "properties": [],
       "prices": {
-        "usd": "6.50"
+        "usd": "6.50",
+        "eur": "5.97",
+        "tix": "7.79"
       }
     },
     {
@@ -34777,7 +36285,9 @@
       "edhrec_rank": 2859,
       "properties": [],
       "prices": {
-        "usd": "1.73"
+        "usd": "1.73",
+        "eur": "1.24",
+        "tix": "0.02"
       }
     },
     {
@@ -34819,7 +36329,9 @@
       "edhrec_rank": 16853,
       "properties": [],
       "prices": {
-        "usd": "1.11"
+        "usd": "1.11",
+        "eur": "0.79",
+        "tix": null
       }
     },
     {
@@ -34867,7 +36379,9 @@
       "edhrec_rank": 499,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.24",
+        "tix": "0.03"
       }
     },
     {
@@ -34909,7 +36423,9 @@
       "edhrec_rank": 11918,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.10",
+        "eur": "0.04",
+        "tix": "0.03"
       }
     },
     {
@@ -34951,7 +36467,9 @@
       "edhrec_rank": 6003,
       "properties": [],
       "prices": {
-        "usd": "4.67"
+        "usd": "4.67",
+        "eur": "3.67",
+        "tix": "6.12"
       }
     },
     {
@@ -34992,7 +36510,9 @@
       "edhrec_rank": 6142,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.13",
+        "tix": "0.03"
       }
     },
     {
@@ -35034,7 +36554,9 @@
       "edhrec_rank": 17319,
       "properties": [],
       "prices": {
-        "usd": "0.82"
+        "usd": "0.82",
+        "eur": "0.60",
+        "tix": "0.06"
       }
     },
     {
@@ -35076,7 +36598,9 @@
       "edhrec_rank": 6495,
       "properties": [],
       "prices": {
-        "usd": "3.13"
+        "usd": "3.13",
+        "eur": "2.08",
+        "tix": "11.82"
       }
     },
     {
@@ -35118,7 +36642,9 @@
       "edhrec_rank": 7886,
       "properties": [],
       "prices": {
-        "usd": "0.55"
+        "usd": "0.55",
+        "eur": "0.22",
+        "tix": "0.03"
       }
     },
     {
@@ -35165,7 +36691,9 @@
       "edhrec_rank": 622,
       "properties": [],
       "prices": {
-        "usd": "0.73"
+        "usd": "0.73",
+        "eur": "0.43",
+        "tix": "0.03"
       }
     },
     {
@@ -35198,7 +36726,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.15",
+        "eur": "0.11",
+        "tix": null
       }
     },
     {
@@ -35247,7 +36777,9 @@
       "edhrec_rank": 490,
       "properties": [],
       "prices": {
-        "usd": "19.51"
+        "usd": "19.51",
+        "eur": "14.61",
+        "tix": "0.13"
       }
     },
     {
@@ -35291,7 +36823,9 @@
       "edhrec_rank": 471,
       "properties": [],
       "prices": {
-        "usd": null
+        "usd": null,
+        "eur": "3083.46",
+        "tix": null
       }
     },
     {
@@ -35336,7 +36870,9 @@
       "edhrec_rank": 21120,
       "properties": [],
       "prices": {
-        "usd": "1.49"
+        "usd": "1.49",
+        "eur": "1.11",
+        "tix": "0.02"
       }
     },
     {
@@ -35373,7 +36909,9 @@
       "edhrec_rank": 49,
       "properties": [],
       "prices": {
-        "usd": "43.27"
+        "usd": "43.27",
+        "eur": "25.62",
+        "tix": "5.50"
       }
     },
     {
@@ -35419,7 +36957,9 @@
       "edhrec_rank": 963,
       "properties": [],
       "prices": {
-        "usd": "0.52"
+        "usd": "0.52",
+        "eur": "0.26",
+        "tix": "0.02"
       }
     },
     {
@@ -35460,7 +37000,9 @@
       "edhrec_rank": 322,
       "properties": [],
       "prices": {
-        "usd": "0.50"
+        "usd": "0.50",
+        "eur": "0.46",
+        "tix": "0.02"
       }
     },
     {
@@ -35505,7 +37047,9 @@
       "edhrec_rank": 2582,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.25",
+        "tix": "0.03"
       }
     },
     {
@@ -35551,7 +37095,9 @@
       "edhrec_rank": 26535,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.22",
+        "tix": null
       }
     },
     {
@@ -35582,7 +37128,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "2.72"
+        "usd": "2.72",
+        "eur": "2.24",
+        "tix": "2.70"
       }
     },
     {
@@ -35622,7 +37170,9 @@
       "edhrec_rank": 6504,
       "properties": [],
       "prices": {
-        "usd": "64.35"
+        "usd": "64.35",
+        "eur": "35.82",
+        "tix": "0.61"
       }
     },
     {
@@ -35666,7 +37216,9 @@
       "edhrec_rank": 706,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -35710,7 +37262,9 @@
       "edhrec_rank": 386,
       "properties": [],
       "prices": {
-        "usd": null
+        "usd": null,
+        "eur": "3162.47",
+        "tix": null
       }
     },
     {
@@ -35748,7 +37302,9 @@
       "edhrec_rank": 8276,
       "properties": [],
       "prices": {
-        "usd": "3.77"
+        "usd": "3.77",
+        "eur": "2.55",
+        "tix": "0.02"
       }
     },
     {
@@ -35795,7 +37351,9 @@
       "edhrec_rank": 2369,
       "properties": [],
       "prices": {
-        "usd": "1.61"
+        "usd": "1.61",
+        "eur": "1.41",
+        "tix": "1.52"
       }
     },
     {
@@ -35865,7 +37423,9 @@
       "edhrec_rank": 673,
       "properties": [],
       "prices": {
-        "usd": "36.76"
+        "usd": "36.76",
+        "eur": "29.50",
+        "tix": "10.85"
       }
     },
     {
@@ -35906,7 +37466,9 @@
       "edhrec_rank": 5307,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.26",
+        "eur": "0.40",
+        "tix": "0.02"
       }
     },
     {
@@ -35951,7 +37513,9 @@
       "edhrec_rank": 166,
       "properties": [],
       "prices": {
-        "usd": "19.87"
+        "usd": "19.87",
+        "eur": "16.30",
+        "tix": "1.79"
       }
     },
     {
@@ -35997,7 +37561,9 @@
       "edhrec_rank": 1212,
       "properties": [],
       "prices": {
-        "usd": "1.94"
+        "usd": "1.94",
+        "eur": "1.36",
+        "tix": "0.02"
       }
     },
     {
@@ -36034,7 +37600,9 @@
       "edhrec_rank": 25660,
       "properties": [],
       "prices": {
-        "usd": "9.18"
+        "usd": "9.18",
+        "eur": "4.32",
+        "tix": null
       }
     },
     {
@@ -36080,7 +37648,9 @@
       "edhrec_rank": 23504,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.19",
+        "tix": "0.06"
       }
     },
     {
@@ -36127,7 +37697,9 @@
       "edhrec_rank": 397,
       "properties": [],
       "prices": {
-        "usd": "1.22"
+        "usd": "1.22",
+        "eur": "0.49",
+        "tix": "0.03"
       }
     },
     {
@@ -36170,7 +37742,9 @@
       "edhrec_rank": 9645,
       "properties": [],
       "prices": {
-        "usd": "0.71"
+        "usd": "0.71",
+        "eur": "0.42",
+        "tix": "0.04"
       }
     },
     {
@@ -36213,7 +37787,9 @@
       "edhrec_rank": 336,
       "properties": [],
       "prices": {
-        "usd": "1.52"
+        "usd": "1.52",
+        "eur": "0.83",
+        "tix": "0.68"
       }
     },
     {
@@ -36258,7 +37834,9 @@
       "edhrec_rank": 223,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.40",
+        "tix": "0.03"
       }
     },
     {
@@ -36303,7 +37881,9 @@
       "edhrec_rank": 4908,
       "properties": [],
       "prices": {
-        "usd": "3.67"
+        "usd": "3.67",
+        "eur": "1.18",
+        "tix": "0.02"
       }
     },
     {
@@ -36342,7 +37922,9 @@
       ],
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.25",
+        "tix": "0.02"
       },
       "edhrec_rank": 4611
     },
@@ -36387,7 +37969,9 @@
       "edhrec_rank": 1380,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.26",
+        "eur": "0.31",
+        "tix": "0.04"
       }
     },
     {
@@ -36449,7 +38033,9 @@
       "edhrec_rank": 14330,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.19",
+        "tix": "0.02"
       }
     },
     {
@@ -36476,7 +38062,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "2.55"
+        "usd": "2.55",
+        "eur": "1.81",
+        "tix": "0.02"
       }
     },
     {
@@ -36522,7 +38110,9 @@
       "edhrec_rank": 1821,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -36566,7 +38156,9 @@
       "edhrec_rank": 4735,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -36636,7 +38228,9 @@
       "edhrec_rank": 978,
       "properties": [],
       "prices": {
-        "usd": "1.66"
+        "usd": "1.66",
+        "eur": "1.90",
+        "tix": "0.03"
       }
     },
     {
@@ -36678,7 +38272,9 @@
       "edhrec_rank": 11244,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.31",
+        "tix": "0.03"
       }
     },
     {
@@ -36724,7 +38320,9 @@
       "edhrec_rank": 1955,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.10",
+        "eur": "0.06",
+        "tix": "0.03"
       }
     },
     {
@@ -36769,7 +38367,9 @@
       "edhrec_rank": 540,
       "properties": [],
       "prices": {
-        "usd": "0.78"
+        "usd": "0.78",
+        "eur": "0.18",
+        "tix": "0.03"
       }
     },
     {
@@ -36811,7 +38411,9 @@
       "edhrec_rank": 9810,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.16",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -36851,7 +38453,9 @@
       "edhrec_rank": 2293,
       "properties": [],
       "prices": {
-        "usd": "1.40"
+        "usd": "1.40",
+        "eur": "1.63",
+        "tix": "0.03"
       }
     },
     {
@@ -36882,7 +38486,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -36925,7 +38531,9 @@
       "edhrec_rank": 3007,
       "properties": [],
       "prices": {
-        "usd": "479.71"
+        "usd": "479.71",
+        "eur": "381.49",
+        "tix": "11.48"
       }
     },
     {
@@ -36970,7 +38578,9 @@
       "edhrec_rank": 423,
       "properties": [],
       "prices": {
-        "usd": "3.11"
+        "usd": "3.11",
+        "eur": "2.33",
+        "tix": "1.72"
       }
     },
     {
@@ -37016,7 +38626,9 @@
       "edhrec_rank": 561,
       "properties": [],
       "prices": {
-        "usd": "12.32"
+        "usd": "12.32",
+        "eur": "12.18",
+        "tix": "1.68"
       }
     },
     {
@@ -37060,7 +38672,9 @@
       "edhrec_rank": 5484,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.25",
+        "tix": "0.02"
       }
     },
     {
@@ -37105,7 +38719,9 @@
       "edhrec_rank": 5359,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.18",
+        "eur": "0.05",
+        "tix": "0.03"
       }
     },
     {
@@ -37151,7 +38767,9 @@
       "edhrec_rank": 1847,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.31",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -37196,7 +38814,9 @@
       "edhrec_rank": 294,
       "properties": [],
       "prices": {
-        "usd": "4.06"
+        "usd": "4.06",
+        "eur": "4.83",
+        "tix": "0.02"
       }
     },
     {
@@ -37265,7 +38885,9 @@
       "edhrec_rank": 1337,
       "properties": [],
       "prices": {
-        "usd": "8.99"
+        "usd": "8.99",
+        "eur": "7.39",
+        "tix": "4.29"
       }
     },
     {
@@ -37308,7 +38930,9 @@
       "edhrec_rank": 5017,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.36",
+        "tix": "0.03"
       }
     },
     {
@@ -37352,7 +38976,9 @@
       "edhrec_rank": 15801,
       "properties": [],
       "prices": {
-        "usd": "2.35"
+        "usd": "2.35",
+        "eur": "2.08",
+        "tix": "0.02"
       }
     },
     {
@@ -37398,7 +39024,9 @@
       "edhrec_rank": 626,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.12",
+        "tix": "0.02"
       }
     },
     {
@@ -37438,7 +39066,9 @@
       "edhrec_rank": 26272,
       "properties": [],
       "prices": {
-        "usd": "0.68"
+        "usd": "0.68",
+        "eur": "1.13",
+        "tix": null
       }
     },
     {
@@ -37484,7 +39114,9 @@
       "edhrec_rank": 2109,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.18",
+        "tix": "0.03"
       }
     },
     {
@@ -37528,7 +39160,9 @@
       "edhrec_rank": 365,
       "properties": [],
       "prices": {
-        "usd": "4.37"
+        "usd": "4.37",
+        "eur": "5.59",
+        "tix": "0.03"
       }
     },
     {
@@ -37573,7 +39207,9 @@
       "edhrec_rank": 6826,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -37619,7 +39255,9 @@
       "edhrec_rank": 11434,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.13",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -37665,7 +39303,9 @@
       "edhrec_rank": 420,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.50",
+        "tix": "0.02"
       }
     },
     {
@@ -37706,7 +39346,9 @@
       "edhrec_rank": 2052,
       "properties": [],
       "prices": {
-        "usd": "18.86"
+        "usd": "18.86",
+        "eur": "9.49",
+        "tix": "0.02"
       }
     },
     {
@@ -37751,7 +39393,9 @@
       "edhrec_rank": 231,
       "properties": [],
       "prices": {
-        "usd": "6.92"
+        "usd": "6.92",
+        "eur": "4.30",
+        "tix": "0.10"
       }
     },
     {
@@ -37792,7 +39436,9 @@
       "edhrec_rank": 2215,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.26",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -37835,7 +39481,9 @@
       "edhrec_rank": 2234,
       "properties": [],
       "prices": {
-        "usd": "3.44"
+        "usd": "3.44",
+        "eur": "2.77",
+        "tix": "1.45"
       }
     },
     {
@@ -37880,7 +39528,9 @@
       "edhrec_rank": 13037,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.38",
+        "tix": "0.04"
       }
     },
     {
@@ -37925,7 +39575,9 @@
       "edhrec_rank": 117,
       "properties": [],
       "prices": {
-        "usd": "33.76"
+        "usd": "33.76",
+        "eur": "12.65",
+        "tix": "8.26"
       }
     },
     {
@@ -37968,7 +39620,9 @@
       "edhrec_rank": 605,
       "properties": [],
       "prices": {
-        "usd": "42.62"
+        "usd": "42.62",
+        "eur": "18.08",
+        "tix": "0.02"
       }
     },
     {
@@ -38009,7 +39663,9 @@
       "edhrec_rank": 1174,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.32",
+        "tix": "0.02"
       }
     },
     {
@@ -38054,7 +39710,9 @@
       "edhrec_rank": 1602,
       "properties": [],
       "prices": {
-        "usd": "6.84"
+        "usd": "6.84",
+        "eur": "4.67",
+        "tix": "1.05"
       }
     },
     {
@@ -38124,7 +39782,9 @@
       "edhrec_rank": 2014,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.41",
+        "eur": "0.46",
+        "tix": "0.03"
       }
     },
     {
@@ -38171,7 +39831,9 @@
       "edhrec_rank": 1165,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.27",
+        "tix": "0.03"
       }
     },
     {
@@ -38219,7 +39881,9 @@
       "edhrec_rank": 6156,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.05",
+        "tix": "0.03"
       }
     },
     {
@@ -38264,7 +39928,9 @@
       "edhrec_rank": 281,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.41",
+        "eur": "0.42",
+        "tix": "0.04"
       }
     },
     {
@@ -38308,7 +39974,9 @@
       "edhrec_rank": 1413,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -38341,7 +40009,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.16",
+        "eur": "0.10",
+        "tix": null
       }
     },
     {
@@ -38411,7 +40081,9 @@
       "edhrec_rank": 178,
       "properties": [],
       "prices": {
-        "usd": "7.00"
+        "usd": "7.00",
+        "eur": "8.18",
+        "tix": "8.74"
       }
     },
     {
@@ -38456,7 +40128,9 @@
       "edhrec_rank": 3158,
       "properties": [],
       "prices": {
-        "usd": "1.77"
+        "usd": "1.77",
+        "eur": "0.77",
+        "tix": "0.03"
       }
     },
     {
@@ -38522,7 +40196,9 @@
       "edhrec_rank": 9920,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -38567,7 +40243,9 @@
       "edhrec_rank": 7556,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.13",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -38639,7 +40317,9 @@
       "edhrec_rank": 10055,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -38684,7 +40364,9 @@
       "edhrec_rank": 349,
       "properties": [],
       "prices": {
-        "usd": "9.67"
+        "usd": "9.67",
+        "eur": "12.88",
+        "tix": "1.80"
       }
     },
     {
@@ -38713,7 +40395,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.16",
+        "tix": "0.01"
       }
     },
     {
@@ -38755,7 +40439,9 @@
       "edhrec_rank": 10047,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.09",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -38800,7 +40486,9 @@
       "edhrec_rank": 21310,
       "properties": [],
       "prices": {
-        "usd": "2.06"
+        "usd": "2.06",
+        "eur": "1.25",
+        "tix": "0.19"
       }
     },
     {
@@ -38847,7 +40535,9 @@
       "edhrec_rank": 3206,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.20",
+        "tix": "0.03"
       }
     },
     {
@@ -38891,7 +40581,9 @@
       "edhrec_rank": 1233,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.43",
+        "tix": "0.02"
       }
     },
     {
@@ -38935,7 +40627,9 @@
       "edhrec_rank": 5152,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.15",
+        "tix": "0.04"
       }
     },
     {
@@ -38996,7 +40690,9 @@
       "edhrec_rank": 5054,
       "properties": [],
       "prices": {
-        "usd": "12.22"
+        "usd": "12.22",
+        "eur": "15.00",
+        "tix": "0.02"
       }
     },
     {
@@ -39040,7 +40736,9 @@
       "edhrec_rank": 3723,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.18",
+        "tix": "0.04"
       }
     },
     {
@@ -39085,7 +40783,9 @@
       "edhrec_rank": 95,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.33",
+        "tix": "0.02"
       }
     },
     {
@@ -39127,7 +40827,9 @@
       "edhrec_rank": 13938,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.18",
+        "eur": "0.20",
+        "tix": "0.03"
       }
     },
     {
@@ -39404,7 +41106,9 @@
       "edhrec_rank": 3738,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.28",
+        "tix": "0.03"
       }
     },
     {
@@ -39446,7 +41150,9 @@
       "edhrec_rank": 12307,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.09",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -39477,7 +41183,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.56"
+        "usd": "0.56",
+        "eur": "0.85",
+        "tix": "0.67"
       }
     },
     {
@@ -39537,7 +41245,9 @@
       "edhrec_rank": 951,
       "properties": [],
       "prices": {
-        "usd": "2.77"
+        "usd": "2.77",
+        "eur": "2.45",
+        "tix": "0.12"
       }
     },
     {
@@ -39582,7 +41292,9 @@
       "edhrec_rank": 15519,
       "properties": [],
       "prices": {
-        "usd": "8.55"
+        "usd": "8.55",
+        "eur": "5.63",
+        "tix": null
       }
     },
     {
@@ -39652,7 +41364,9 @@
       "edhrec_rank": 5833,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.19",
+        "eur": "0.22",
+        "tix": "0.03"
       }
     },
     {
@@ -39689,7 +41403,9 @@
       "edhrec_rank": 23144,
       "properties": [],
       "prices": {
-        "usd": "10.70"
+        "usd": "10.70",
+        "eur": "8.83",
+        "tix": null
       }
     },
     {
@@ -39730,7 +41446,9 @@
       "edhrec_rank": 6096,
       "properties": [],
       "prices": {
-        "usd": "0.63"
+        "usd": "0.63",
+        "eur": "2.00",
+        "tix": "0.02"
       }
     },
     {
@@ -39775,7 +41493,9 @@
       "edhrec_rank": 5383,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -39825,7 +41545,9 @@
       "edhrec_rank": 392,
       "properties": [],
       "prices": {
-        "usd": "14.14"
+        "usd": "14.14",
+        "eur": "11.76",
+        "tix": "0.21"
       }
     },
     {
@@ -39882,7 +41604,9 @@
       "edhrec_rank": 4173,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.26",
+        "eur": "0.18",
+        "tix": "0.03"
       }
     },
     {
@@ -39924,7 +41648,9 @@
       "edhrec_rank": 13865,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.43",
+        "tix": "0.04"
       }
     },
     {
@@ -39957,7 +41683,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.18",
+        "eur": "0.07",
+        "tix": "0.01"
       }
     },
     {
@@ -40002,7 +41730,9 @@
       "edhrec_rank": 171,
       "properties": [],
       "prices": {
-        "usd": "16.22"
+        "usd": "16.22",
+        "eur": "12.67",
+        "tix": "7.15"
       }
     },
     {
@@ -40072,7 +41802,9 @@
       "edhrec_rank": 2855,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.39",
+        "eur": "0.35",
+        "tix": "0.03"
       }
     },
     {
@@ -40116,7 +41848,9 @@
       "edhrec_rank": 746,
       "properties": [],
       "prices": {
-        "usd": "1.23"
+        "usd": "1.23",
+        "eur": "0.65",
+        "tix": "0.02"
       }
     },
     {
@@ -40161,7 +41895,9 @@
       "edhrec_rank": 187,
       "properties": [],
       "prices": {
-        "usd": "15.27"
+        "usd": "15.27",
+        "eur": "12.01",
+        "tix": "1.40"
       }
     },
     {
@@ -40207,7 +41943,9 @@
       "edhrec_rank": 391,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.43",
+        "tix": "0.02"
       }
     },
     {
@@ -40252,7 +41990,9 @@
       "edhrec_rank": 1572,
       "properties": [],
       "prices": {
-        "usd": "6.37"
+        "usd": "6.37",
+        "eur": "3.95",
+        "tix": "0.96"
       }
     },
     {
@@ -40313,7 +42053,9 @@
       "edhrec_rank": 11879,
       "properties": [],
       "prices": {
-        "usd": "1.07"
+        "usd": "1.07",
+        "eur": "0.68",
+        "tix": "0.02"
       }
     },
     {
@@ -40357,7 +42099,9 @@
       "edhrec_rank": 1145,
       "properties": [],
       "prices": {
-        "usd": "0.85"
+        "usd": "0.85",
+        "eur": "1.11",
+        "tix": "0.02"
       }
     },
     {
@@ -40397,7 +42141,9 @@
       "edhrec_rank": 17069,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.38",
+        "tix": "0.04"
       }
     },
     {
@@ -40440,7 +42186,9 @@
       "edhrec_rank": 11070,
       "properties": [],
       "prices": {
-        "usd": "0.57"
+        "usd": "0.57",
+        "eur": "0.37",
+        "tix": "0.04"
       }
     },
     {
@@ -40486,7 +42234,9 @@
       "edhrec_rank": 895,
       "properties": [],
       "prices": {
-        "usd": "10.52"
+        "usd": "10.52",
+        "eur": "10.91",
+        "tix": "8.52"
       }
     },
     {
@@ -40531,7 +42281,9 @@
       "edhrec_rank": 67,
       "properties": [],
       "prices": {
-        "usd": "23.60"
+        "usd": "23.60",
+        "eur": "13.69",
+        "tix": "0.33"
       }
     },
     {
@@ -40575,7 +42327,9 @@
       "edhrec_rank": 13219,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.21",
+        "tix": "0.02"
       }
     },
     {
@@ -40619,7 +42373,9 @@
       "edhrec_rank": 7142,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.38",
+        "tix": "0.02"
       }
     },
     {
@@ -40664,7 +42420,9 @@
       "edhrec_rank": 68,
       "properties": [],
       "prices": {
-        "usd": "14.36"
+        "usd": "14.36",
+        "eur": "10.11",
+        "tix": "0.13"
       }
     },
     {
@@ -40709,7 +42467,9 @@
       "edhrec_rank": 5464,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.14",
+        "eur": "0.08",
+        "tix": "0.04"
       }
     },
     {
@@ -40754,7 +42514,9 @@
       "edhrec_rank": 203,
       "properties": [],
       "prices": {
-        "usd": "3.94"
+        "usd": "3.94",
+        "eur": "2.80",
+        "tix": "0.02"
       }
     },
     {
@@ -40799,7 +42561,9 @@
       "edhrec_rank": 8572,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -40874,7 +42638,9 @@
       "edhrec_rank": 1923,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.27",
+        "tix": "0.03"
       }
     },
     {
@@ -40915,7 +42681,9 @@
       "edhrec_rank": 519,
       "properties": [],
       "prices": {
-        "usd": "64.76"
+        "usd": "64.76",
+        "eur": "31.07",
+        "tix": null
       }
     },
     {
@@ -40977,7 +42745,9 @@
       "edhrec_rank": 13185,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.19",
+        "tix": "0.02"
       }
     },
     {
@@ -41024,7 +42794,9 @@
       "edhrec_rank": 4343,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.21",
+        "eur": "0.17",
+        "tix": null
       }
     },
     {
@@ -41097,7 +42869,9 @@
       "edhrec_rank": 1250,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.37",
+        "eur": "0.35",
+        "tix": "0.03"
       }
     },
     {
@@ -41142,7 +42916,9 @@
       "edhrec_rank": 4932,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -41184,7 +42960,9 @@
       "edhrec_rank": 19013,
       "properties": [],
       "prices": {
-        "usd": "0.45"
+        "usd": "0.45",
+        "eur": "0.23",
+        "tix": "0.04"
       }
     },
     {
@@ -41217,7 +42995,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.17",
+        "eur": "0.09",
+        "tix": null
       }
     },
     {
@@ -41262,7 +43042,9 @@
       "edhrec_rank": 83,
       "properties": [],
       "prices": {
-        "usd": "0.70"
+        "usd": "0.70",
+        "eur": "0.97",
+        "tix": "0.02"
       }
     },
     {
@@ -41308,7 +43090,9 @@
       "edhrec_rank": 21149,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.16",
+        "tix": "0.05"
       }
     },
     {
@@ -41353,7 +43137,9 @@
       "edhrec_rank": 5360,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.32",
+        "tix": "0.03"
       }
     },
     {
@@ -41398,7 +43184,9 @@
       "edhrec_rank": 158,
       "properties": [],
       "prices": {
-        "usd": "18.07"
+        "usd": "18.07",
+        "eur": "14.16",
+        "tix": null
       }
     },
     {
@@ -41429,7 +43217,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.13",
+        "tix": "0.03"
       }
     },
     {
@@ -41474,7 +43264,9 @@
       "edhrec_rank": 1474,
       "properties": [],
       "prices": {
-        "usd": "4.17"
+        "usd": "4.17",
+        "eur": "3.52",
+        "tix": "3.24"
       }
     },
     {
@@ -41519,7 +43311,9 @@
       "edhrec_rank": 967,
       "properties": [],
       "prices": {
-        "usd": "11.13"
+        "usd": "11.13",
+        "eur": "9.82",
+        "tix": "0.03"
       }
     },
     {
@@ -41589,7 +43383,9 @@
       "edhrec_rank": 734,
       "properties": [],
       "prices": {
-        "usd": "0.94"
+        "usd": "0.94",
+        "eur": "1.42",
+        "tix": "0.04"
       }
     },
     {
@@ -41634,7 +43430,9 @@
       "edhrec_rank": 292,
       "properties": [],
       "prices": {
-        "usd": "5.77"
+        "usd": "5.77",
+        "eur": "4.02",
+        "tix": "0.03"
       }
     },
     {
@@ -41679,7 +43477,9 @@
       "edhrec_rank": 439,
       "properties": [],
       "prices": {
-        "usd": "2.62"
+        "usd": "2.62",
+        "eur": "1.92",
+        "tix": "1.57"
       }
     },
     {
@@ -41724,7 +43524,9 @@
       "edhrec_rank": 1767,
       "properties": [],
       "prices": {
-        "usd": "0.43"
+        "usd": "0.43",
+        "eur": "0.39",
+        "tix": "0.03"
       }
     },
     {
@@ -41768,7 +43570,9 @@
       "edhrec_rank": 6028,
       "properties": [],
       "prices": {
-        "usd": "0.48"
+        "usd": "0.48",
+        "eur": "0.69",
+        "tix": "0.13"
       }
     },
     {
@@ -41813,7 +43617,9 @@
       "edhrec_rank": 86,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.51",
+        "tix": "0.02"
       }
     },
     {
@@ -41855,7 +43661,9 @@
       "edhrec_rank": 4274,
       "properties": [],
       "prices": {
-        "usd": "0.87"
+        "usd": "0.87",
+        "eur": null,
+        "tix": "1.00"
       }
     },
     {
@@ -41901,7 +43709,9 @@
       "edhrec_rank": 1048,
       "properties": [],
       "prices": {
-        "usd": "12.57"
+        "usd": "12.57",
+        "eur": "6.80",
+        "tix": "0.02"
       }
     },
     {
@@ -41946,7 +43756,9 @@
       "edhrec_rank": 1720,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.22",
+        "tix": "0.03"
       }
     },
     {
@@ -41990,7 +43802,9 @@
       "edhrec_rank": 136,
       "properties": [],
       "prices": {
-        "usd": "1.97"
+        "usd": "1.97",
+        "eur": "1.14",
+        "tix": "0.02"
       }
     },
     {
@@ -42047,7 +43861,9 @@
       "edhrec_rank": 3180,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.31",
+        "eur": "0.20",
+        "tix": "0.03"
       }
     },
     {
@@ -42092,7 +43908,9 @@
       "edhrec_rank": 858,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.31",
+        "tix": "0.43"
       }
     },
     {
@@ -42181,7 +43999,9 @@
       "edhrec_rank": 7154,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.20",
+        "tix": "0.03"
       }
     },
     {
@@ -42226,7 +44046,9 @@
       "edhrec_rank": 17009,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.14",
+        "eur": "0.06",
+        "tix": "0.03"
       }
     },
     {
@@ -42272,7 +44094,9 @@
       "edhrec_rank": 2567,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.37",
+        "eur": "0.45",
+        "tix": "0.03"
       }
     },
     {
@@ -42315,7 +44139,9 @@
       "edhrec_rank": 2193,
       "properties": [],
       "prices": {
-        "usd": "4.78"
+        "usd": "4.78",
+        "eur": "4.77",
+        "tix": "0.50"
       }
     },
     {
@@ -42359,7 +44185,9 @@
       "edhrec_rank": 11856,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -42401,7 +44229,9 @@
       "edhrec_rank": 14235,
       "properties": [],
       "prices": {
-        "usd": "2.13"
+        "usd": "2.13",
+        "eur": "1.77",
+        "tix": null
       }
     },
     {
@@ -42440,7 +44270,9 @@
       "edhrec_rank": 1033,
       "properties": [],
       "prices": {
-        "usd": "5.84"
+        "usd": "5.84",
+        "eur": "3.73",
+        "tix": "0.02"
       }
     },
     {
@@ -42484,7 +44316,9 @@
       "edhrec_rank": 1006,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.19",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -42528,7 +44362,9 @@
       "edhrec_rank": 440,
       "properties": [],
       "prices": {
-        "usd": null
+        "usd": null,
+        "eur": "4326.12",
+        "tix": null
       }
     },
     {
@@ -42573,7 +44409,9 @@
       "edhrec_rank": 421,
       "properties": [],
       "prices": {
-        "usd": "1.59"
+        "usd": "1.59",
+        "eur": "1.79",
+        "tix": "0.29"
       }
     },
     {
@@ -42618,7 +44456,9 @@
       "edhrec_rank": 496,
       "properties": [],
       "prices": {
-        "usd": "1.25"
+        "usd": "1.25",
+        "eur": "1.26",
+        "tix": "0.07"
       }
     },
     {
@@ -42663,7 +44503,9 @@
       "edhrec_rank": 500,
       "properties": [],
       "prices": {
-        "usd": "2.23"
+        "usd": "2.23",
+        "eur": "1.07",
+        "tix": "0.04"
       }
     },
     {
@@ -42708,7 +44550,9 @@
       "edhrec_rank": 424,
       "properties": [],
       "prices": {
-        "usd": "1.07"
+        "usd": "1.07",
+        "eur": "1.01",
+        "tix": "0.60"
       }
     },
     {
@@ -42753,7 +44597,9 @@
       "edhrec_rank": 242,
       "properties": [],
       "prices": {
-        "usd": "10.18"
+        "usd": "10.18",
+        "eur": "9.34",
+        "tix": "0.06"
       }
     },
     {
@@ -42798,7 +44644,9 @@
       "edhrec_rank": 585,
       "properties": [],
       "prices": {
-        "usd": "33.97"
+        "usd": "33.97",
+        "eur": null,
+        "tix": "17.87"
       }
     },
     {
@@ -42870,7 +44718,9 @@
       "edhrec_rank": 3182,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.32",
+        "tix": "0.03"
       }
     },
     {
@@ -42915,7 +44765,9 @@
       "edhrec_rank": 1279,
       "properties": [],
       "prices": {
-        "usd": "0.25"
+        "usd": "0.25",
+        "eur": "0.18",
+        "tix": "0.03"
       }
     },
     {
@@ -42962,7 +44814,9 @@
       "edhrec_rank": 3125,
       "properties": [],
       "prices": {
-        "usd": "0.31"
+        "usd": "0.31",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -43006,7 +44860,9 @@
       "edhrec_rank": 8725,
       "properties": [],
       "prices": {
-        "usd": "0.64"
+        "usd": "0.64",
+        "eur": "1.13",
+        "tix": "0.02"
       }
     },
     {
@@ -43051,7 +44907,9 @@
       "edhrec_rank": 2598,
       "properties": [],
       "prices": {
-        "usd": "18.28"
+        "usd": "18.28",
+        "eur": "11.08",
+        "tix": "4.50"
       }
     },
     {
@@ -43082,7 +44940,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.13",
+        "eur": "0.10",
+        "tix": "0.01"
       }
     },
     {
@@ -43123,7 +44983,9 @@
       "edhrec_rank": 3767,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.21",
+        "eur": "0.33",
+        "tix": "0.03"
       }
     },
     {
@@ -43165,7 +45027,9 @@
       "edhrec_rank": 14983,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.10",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -43210,7 +45074,9 @@
       "edhrec_rank": 17473,
       "properties": [],
       "prices": {
-        "usd": "11.63"
+        "usd": "11.63",
+        "eur": "5.15",
+        "tix": "6.32"
       }
     },
     {
@@ -43255,7 +45121,9 @@
       "edhrec_rank": 82,
       "properties": [],
       "prices": {
-        "usd": "15.42"
+        "usd": "15.42",
+        "eur": "11.49",
+        "tix": "0.02"
       }
     },
     {
@@ -43301,7 +45169,9 @@
       "edhrec_rank": 484,
       "properties": [],
       "prices": {
-        "usd": "0.29"
+        "usd": "0.29",
+        "eur": "0.34",
+        "tix": "0.02"
       }
     },
     {
@@ -43347,7 +45217,9 @@
       "edhrec_rank": 332,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.45",
+        "tix": "0.02"
       }
     },
     {
@@ -43391,7 +45263,9 @@
       "edhrec_rank": 302,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.39",
+        "tix": "0.02"
       }
     },
     {
@@ -43437,7 +45311,9 @@
       "edhrec_rank": 270,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.32",
+        "tix": "0.02"
       }
     },
     {
@@ -43483,7 +45359,9 @@
       "edhrec_rank": 343,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.26",
+        "tix": "0.02"
       }
     },
     {
@@ -43529,7 +45407,9 @@
       "edhrec_rank": 415,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.41",
+        "tix": "0.02"
       }
     },
     {
@@ -43575,7 +45455,9 @@
       "edhrec_rank": 298,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.42",
+        "tix": "0.02"
       }
     },
     {
@@ -43621,7 +45503,9 @@
       "edhrec_rank": 479,
       "properties": [],
       "prices": {
-        "usd": "0.42"
+        "usd": "0.42",
+        "eur": "0.45",
+        "tix": "0.02"
       }
     },
     {
@@ -43667,7 +45551,9 @@
       "edhrec_rank": 276,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.37",
+        "eur": "0.34",
+        "tix": "0.02"
       }
     },
     {
@@ -43711,7 +45597,9 @@
       "edhrec_rank": 2490,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.24",
+        "tix": "0.03"
       }
     },
     {
@@ -43752,7 +45640,9 @@
       "edhrec_rank": 74,
       "properties": [],
       "prices": {
-        "usd": "0.78"
+        "usd": "0.78",
+        "eur": "0.57",
+        "tix": "0.04"
       }
     },
     {
@@ -43798,7 +45688,9 @@
       "edhrec_rank": 288,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.37",
+        "tix": "0.02"
       }
     },
     {
@@ -43843,7 +45735,9 @@
       "edhrec_rank": 7082,
       "properties": [],
       "prices": {
-        "usd": "1.76"
+        "usd": "1.76",
+        "eur": "0.96",
+        "tix": "0.02"
       }
     },
     {
@@ -43883,7 +45777,9 @@
       "edhrec_rank": 11273,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.21",
+        "tix": "0.04"
       }
     },
     {
@@ -43923,7 +45819,9 @@
       "edhrec_rank": 1904,
       "properties": [],
       "prices": {
-        "usd": "3.55"
+        "usd": "3.55",
+        "eur": "1.57",
+        "tix": "0.39"
       }
     },
     {
@@ -43961,7 +45859,9 @@
       "edhrec_rank": 28,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.18",
+        "eur": "0.21",
+        "tix": "0.03"
       }
     },
     {
@@ -44006,7 +45906,9 @@
       "edhrec_rank": 24552,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.22",
+        "tix": "0.04"
       }
     },
     {
@@ -44043,7 +45945,9 @@
       "edhrec_rank": 11717,
       "properties": [],
       "prices": {
-        "usd": "25.41"
+        "usd": "25.41",
+        "eur": "12.63",
+        "tix": null
       }
     },
     {
@@ -44086,7 +45990,9 @@
       "edhrec_rank": 7810,
       "properties": [],
       "prices": {
-        "usd": "0.14"
+        "usd": "0.14",
+        "eur": "0.06",
+        "tix": "0.03"
       }
     },
     {
@@ -44126,7 +46032,9 @@
       "edhrec_rank": 15692,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.20",
+        "tix": "0.02"
       }
     },
     {
@@ -44168,7 +46076,9 @@
       "edhrec_rank": 1199,
       "properties": [],
       "prices": {
-        "usd": "9.47"
+        "usd": "9.47",
+        "eur": "10.36",
+        "tix": "4.01"
       }
     },
     {
@@ -44211,7 +46121,9 @@
       "edhrec_rank": 7176,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.06",
+        "tix": "0.03"
       }
     },
     {
@@ -44254,7 +46166,9 @@
       "edhrec_rank": 6695,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.18",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -44313,7 +46227,9 @@
       "edhrec_rank": 3870,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.17",
+        "tix": "0.03"
       }
     },
     {
@@ -44361,7 +46277,9 @@
       "edhrec_rank": 1529,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -44404,7 +46322,9 @@
       "edhrec_rank": 6819,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.15",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -44444,7 +46364,9 @@
       "edhrec_rank": 13177,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.26",
+        "eur": "0.11",
+        "tix": "0.02"
       }
     },
     {
@@ -44490,7 +46412,9 @@
       "edhrec_rank": 875,
       "properties": [],
       "prices": {
-        "usd": "1.41"
+        "usd": "1.41",
+        "eur": "0.87",
+        "tix": "0.25"
       }
     },
     {
@@ -44537,7 +46461,9 @@
       "edhrec_rank": 5642,
       "properties": [],
       "prices": {
-        "usd": "0.35"
+        "usd": "0.35",
+        "eur": "0.33",
+        "tix": "0.02"
       }
     },
     {
@@ -44598,7 +46524,9 @@
       "edhrec_rank": 1136,
       "properties": [],
       "prices": {
-        "usd": "3.95"
+        "usd": "3.95",
+        "eur": "1.53",
+        "tix": "0.02"
       }
     },
     {
@@ -44641,7 +46569,9 @@
       "edhrec_rank": 8817,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -44678,7 +46608,9 @@
       "edhrec_rank": 8944,
       "properties": [],
       "prices": {
-        "usd": "2899.99"
+        "usd": "2899.99",
+        "eur": "2498.86",
+        "tix": null
       }
     },
     {
@@ -44728,7 +46660,9 @@
       "edhrec_rank": 783,
       "properties": [],
       "prices": {
-        "usd": "7.59"
+        "usd": "7.59",
+        "eur": "5.03",
+        "tix": "0.02"
       }
     },
     {
@@ -44769,7 +46703,9 @@
       "edhrec_rank": 552,
       "properties": [],
       "prices": {
-        "usd": "0.55"
+        "usd": "0.55",
+        "eur": "0.71",
+        "tix": "0.02"
       }
     },
     {
@@ -44816,7 +46752,9 @@
       "edhrec_rank": 4449,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -44861,7 +46799,9 @@
       "edhrec_rank": 808,
       "properties": [],
       "prices": {
-        "usd": "5.13"
+        "usd": "5.13",
+        "eur": "4.72",
+        "tix": "0.03"
       }
     },
     {
@@ -44905,7 +46845,9 @@
       "edhrec_rank": 1023,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.12",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -44958,7 +46900,9 @@
       "edhrec_rank": 4501,
       "properties": [],
       "prices": {
-        "usd": "0.74"
+        "usd": "0.74",
+        "eur": "0.48",
+        "tix": "0.02"
       }
     },
     {
@@ -45002,7 +46946,9 @@
       "edhrec_rank": 14165,
       "properties": [],
       "prices": {
-        "usd": "4.73"
+        "usd": "4.73",
+        "eur": "4.86",
+        "tix": "8.20"
       }
     },
     {
@@ -45047,7 +46993,9 @@
       "edhrec_rank": 183,
       "properties": [],
       "prices": {
-        "usd": "23.17"
+        "usd": "23.17",
+        "eur": "18.72",
+        "tix": "0.02"
       }
     },
     {
@@ -45094,7 +47042,9 @@
       "edhrec_rank": 1210,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.10",
+        "tix": "0.05"
       }
     },
     {
@@ -45141,7 +47091,9 @@
       "edhrec_rank": 1213,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.07",
+        "tix": "0.04"
       }
     },
     {
@@ -45188,7 +47140,9 @@
       "edhrec_rank": 1080,
       "properties": [],
       "prices": {
-        "usd": "0.17"
+        "usd": "0.17",
+        "eur": "0.07",
+        "tix": "0.04"
       }
     },
     {
@@ -45235,7 +47189,9 @@
       "edhrec_rank": 1029,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.16",
+        "tix": "0.04"
       }
     },
     {
@@ -45282,7 +47238,9 @@
       "edhrec_rank": 1228,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.09",
+        "tix": "0.05"
       }
     },
     {
@@ -45327,7 +47285,9 @@
       "edhrec_rank": 18080,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.12",
+        "tix": "0.02"
       }
     },
     {
@@ -45384,7 +47344,9 @@
       "edhrec_rank": 4627,
       "properties": [],
       "prices": {
-        "usd": "0.49"
+        "usd": "0.49",
+        "eur": "0.26",
+        "tix": null
       }
     },
     {
@@ -45430,7 +47392,9 @@
       "edhrec_rank": 625,
       "properties": [],
       "prices": {
-        "usd": "16.13"
+        "usd": "16.13",
+        "eur": "14.34",
+        "tix": "8.41"
       }
     },
     {
@@ -45475,7 +47439,9 @@
       "edhrec_rank": 8565,
       "properties": [],
       "prices": {
-        "usd": "0.06"
+        "usd": "0.06",
+        "eur": "0.09",
+        "tix": "0.03"
       }
     },
     {
@@ -45521,7 +47487,9 @@
       "edhrec_rank": 23343,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.19",
+        "eur": "0.07",
+        "tix": "0.12"
       }
     },
     {
@@ -45565,7 +47533,9 @@
       "edhrec_rank": 29083,
       "properties": [],
       "prices": {
-        "usd": "0.99"
+        "usd": "0.99",
+        "eur": "1.33",
+        "tix": null
       }
     },
     {
@@ -45611,7 +47581,9 @@
       "edhrec_rank": 21246,
       "properties": [],
       "prices": {
-        "usd": "0.18"
+        "usd": "0.18",
+        "eur": "0.14",
+        "tix": "0.15"
       }
     },
     {
@@ -45644,7 +47616,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.07",
+        "tix": "0.01"
       }
     },
     {
@@ -45687,7 +47661,9 @@
       "edhrec_rank": 5916,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -45730,7 +47706,9 @@
       "edhrec_rank": 18029,
       "properties": [],
       "prices": {
-        "usd": "7.07"
+        "usd": "7.07",
+        "eur": "6.40",
+        "tix": null
       }
     },
     {
@@ -45774,7 +47752,9 @@
       "edhrec_rank": 3271,
       "properties": [],
       "prices": {
-        "usd": "1.96"
+        "usd": "1.96",
+        "eur": "1.23",
+        "tix": "0.47"
       }
     },
     {
@@ -45818,7 +47798,9 @@
       "edhrec_rank": 4838,
       "properties": [],
       "prices": {
-        "usd": "4.82"
+        "usd": "4.82",
+        "eur": "4.68",
+        "tix": "6.06"
       }
     },
     {
@@ -45859,7 +47841,9 @@
       "edhrec_rank": 1680,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.15",
+        "tix": "0.03"
       }
     },
     {
@@ -45901,7 +47885,9 @@
       "edhrec_rank": 17303,
       "properties": [],
       "prices": {
-        "usd": "4.04"
+        "usd": "4.04",
+        "eur": "0.96",
+        "tix": "0.02"
       }
     },
     {
@@ -45949,7 +47935,9 @@
       "edhrec_rank": 11329,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -45990,7 +47978,9 @@
       "edhrec_rank": 10078,
       "properties": [],
       "prices": {
-        "usd": "8.78"
+        "usd": "8.78",
+        "eur": "4.46",
+        "tix": "1.92"
       }
     },
     {
@@ -46035,7 +48025,9 @@
       "edhrec_rank": 149,
       "properties": [],
       "prices": {
-        "usd": "16.13"
+        "usd": "16.13",
+        "eur": "13.44",
+        "tix": "10.56"
       }
     },
     {
@@ -46080,7 +48072,9 @@
       "edhrec_rank": 6888,
       "properties": [],
       "prices": {
-        "usd": "0.13"
+        "usd": "0.13",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -46124,7 +48118,9 @@
       "edhrec_rank": 1075,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.09",
+        "eur": "0.04",
+        "tix": "0.03"
       }
     },
     {
@@ -46169,7 +48165,9 @@
       "edhrec_rank": 7844,
       "properties": [],
       "prices": {
-        "usd": "0.08"
+        "usd": "0.08",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -46214,7 +48212,9 @@
       "edhrec_rank": 22993,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -46260,7 +48260,9 @@
       "edhrec_rank": 1881,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -46304,7 +48306,9 @@
       "edhrec_rank": 964,
       "properties": [],
       "prices": {
-        "usd": "0.32"
+        "usd": "0.32",
+        "eur": "0.29",
+        "tix": "0.04"
       }
     },
     {
@@ -46348,7 +48352,9 @@
       "edhrec_rank": 7911,
       "properties": [],
       "prices": {
-        "usd": "0.08"
+        "usd": "0.08",
+        "eur": "0.05",
+        "tix": "0.03"
       }
     },
     {
@@ -46407,7 +48413,9 @@
       "edhrec_rank": 501,
       "properties": [],
       "prices": {
-        "usd": "1.51"
+        "usd": "1.51",
+        "eur": "1.61",
+        "tix": "0.03"
       }
     },
     {
@@ -46450,7 +48458,9 @@
       "edhrec_rank": 1553,
       "properties": [],
       "prices": {
-        "usd": "1.57"
+        "usd": "1.57",
+        "eur": "0.66",
+        "tix": "0.03"
       }
     },
     {
@@ -46492,7 +48502,9 @@
       "edhrec_rank": 5612,
       "properties": [],
       "prices": {
-        "usd": "4.30"
+        "usd": "4.30",
+        "eur": "3.60",
+        "tix": "3.15"
       }
     },
     {
@@ -46535,7 +48547,9 @@
       "edhrec_rank": 7503,
       "properties": [],
       "prices": {
-        "usd": "0.46"
+        "usd": "0.46",
+        "eur": null,
+        "tix": "2.75"
       }
     },
     {
@@ -46580,7 +48594,9 @@
       "edhrec_rank": 4915,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -46622,7 +48638,9 @@
       "edhrec_rank": 4510,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.27",
+        "tix": null
       }
     },
     {
@@ -46667,7 +48685,9 @@
       "edhrec_rank": 19144,
       "properties": [],
       "prices": {
-        "usd": "0.51"
+        "usd": "0.51",
+        "eur": "0.36",
+        "tix": "0.03"
       }
     },
     {
@@ -46713,7 +48733,9 @@
       "edhrec_rank": 10011,
       "properties": [],
       "prices": {
-        "usd": "1.86"
+        "usd": "1.86",
+        "eur": "2.76",
+        "tix": "0.80"
       }
     },
     {
@@ -46773,7 +48795,9 @@
       "edhrec_rank": 363,
       "properties": [],
       "prices": {
-        "usd": null
+        "usd": null,
+        "eur": "6659.52",
+        "tix": null
       }
     },
     {
@@ -46817,7 +48841,9 @@
       "edhrec_rank": 368,
       "properties": [],
       "prices": {
-        "usd": "3000.00"
+        "usd": "3000.00",
+        "eur": "4677.58",
+        "tix": null
       }
     },
     {
@@ -46848,7 +48874,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "7.72"
+        "usd": "7.72",
+        "eur": "6.92",
+        "tix": "4.81"
       }
     },
     {
@@ -46879,7 +48907,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "5.92"
+        "usd": "5.92",
+        "eur": "6.31",
+        "tix": "5.23"
       }
     },
     {
@@ -46910,7 +48940,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "5.61"
+        "usd": "5.61",
+        "eur": "6.22",
+        "tix": "3.79"
       }
     },
     {
@@ -46941,7 +48973,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "5.46"
+        "usd": "5.46",
+        "eur": "5.75",
+        "tix": "3.92"
       }
     },
     {
@@ -46972,7 +49006,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "6.41"
+        "usd": "6.41",
+        "eur": "6.16",
+        "tix": "3.03"
       }
     },
     {
@@ -47014,7 +49050,9 @@
       "edhrec_rank": 17891,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.10",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -47083,7 +49121,9 @@
       "edhrec_rank": 2261,
       "properties": [],
       "prices": {
-        "usd": "2.78"
+        "usd": "2.78",
+        "eur": "3.06",
+        "tix": "3.34"
       }
     },
     {
@@ -47115,7 +49155,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.17",
+        "tix": "0.02"
       }
     },
     {
@@ -47161,7 +49203,9 @@
       "edhrec_rank": 383,
       "properties": [],
       "prices": {
-        "usd": "5.19"
+        "usd": "5.19",
+        "eur": "3.30",
+        "tix": "0.02"
       }
     },
     {
@@ -47207,7 +49251,9 @@
       "edhrec_rank": 1703,
       "properties": [],
       "prices": {
-        "usd": "0.24"
+        "usd": "0.24",
+        "eur": "0.15",
+        "tix": "0.03"
       }
     },
     {
@@ -47247,7 +49293,9 @@
       "edhrec_rank": 1059,
       "properties": [],
       "prices": {
-        "usd": "2.85"
+        "usd": "2.85",
+        "eur": "1.73",
+        "tix": "0.02"
       }
     },
     {
@@ -47289,7 +49337,9 @@
       "edhrec_rank": 2826,
       "properties": [],
       "prices": {
-        "usd": "13.32"
+        "usd": "13.32",
+        "eur": "15.54",
+        "tix": "10.10"
       }
     },
     {
@@ -47361,7 +49411,9 @@
       "edhrec_rank": 14186,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.21",
+        "eur": "0.29",
+        "tix": "0.03"
       }
     },
     {
@@ -47394,7 +49446,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.62"
+        "usd": "0.62",
+        "eur": "0.70",
+        "tix": "1.39"
       }
     },
     {
@@ -47439,7 +49493,9 @@
       "edhrec_rank": 2730,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -47484,7 +49540,9 @@
       "edhrec_rank": 243,
       "properties": [],
       "prices": {
-        "usd": "0.49"
+        "usd": "0.49",
+        "eur": "0.42",
+        "tix": "0.03"
       }
     },
     {
@@ -47530,7 +49588,9 @@
       "edhrec_rank": 433,
       "properties": [],
       "prices": {
-        "usd": "17.78"
+        "usd": "17.78",
+        "eur": "19.04",
+        "tix": "9.08"
       }
     },
     {
@@ -47570,7 +49630,9 @@
       "edhrec_rank": 6598,
       "properties": [],
       "prices": {
-        "usd": "0.50"
+        "usd": "0.50",
+        "eur": "0.28",
+        "tix": "4.85"
       }
     },
     {
@@ -47616,7 +49678,9 @@
       "edhrec_rank": 470,
       "properties": [],
       "prices": {
-        "usd": "16.51"
+        "usd": "16.51",
+        "eur": "14.62",
+        "tix": "1.44"
       }
     },
     {
@@ -47661,7 +49725,9 @@
       "edhrec_rank": 152,
       "properties": [],
       "prices": {
-        "usd": "33.89"
+        "usd": "33.89",
+        "eur": "20.48",
+        "tix": null
       }
     },
     {
@@ -47705,7 +49771,9 @@
       "edhrec_rank": 300,
       "properties": [],
       "prices": {
-        "usd": null
+        "usd": null,
+        "eur": "12802.84",
+        "tix": null
       }
     },
     {
@@ -47750,7 +49818,9 @@
       "edhrec_rank": 175,
       "properties": [],
       "prices": {
-        "usd": "7.17"
+        "usd": "7.17",
+        "eur": "8.11",
+        "tix": "2.67"
       }
     },
     {
@@ -47795,7 +49865,9 @@
       "edhrec_rank": 16577,
       "properties": [],
       "prices": {
-        "usd": "37.61"
+        "usd": "37.61",
+        "eur": "21.62",
+        "tix": "8.10"
       }
     },
     {
@@ -47832,7 +49904,9 @@
       "edhrec_rank": 25332,
       "properties": [],
       "prices": {
-        "usd": "5.63"
+        "usd": "5.63",
+        "eur": "5.79",
+        "tix": null
       }
     },
     {
@@ -47874,7 +49948,9 @@
       "edhrec_rank": 2958,
       "properties": [],
       "prices": {
-        "usd": "6.65"
+        "usd": "6.65",
+        "eur": "5.20",
+        "tix": "0.45"
       }
     },
     {
@@ -47907,7 +49983,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.16"
+        "usd": "0.16",
+        "eur": "0.08",
+        "tix": null
       }
     },
     {
@@ -47953,7 +50031,9 @@
       "edhrec_rank": 7534,
       "properties": [],
       "prices": {
-        "usd": "0.10"
+        "usd": "0.10",
+        "eur": "0.10",
+        "tix": "0.03"
       }
     },
     {
@@ -47994,7 +50074,9 @@
       "edhrec_rank": 20597,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -48035,7 +50117,9 @@
       "edhrec_rank": 9901,
       "properties": [],
       "prices": {
-        "usd": "5.73"
+        "usd": "5.73",
+        "eur": "1.73",
+        "tix": "0.02"
       }
     },
     {
@@ -48068,7 +50152,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.59"
+        "usd": "0.59",
+        "eur": "0.45",
+        "tix": null
       }
     },
     {
@@ -48111,7 +50197,9 @@
       "edhrec_rank": 9049,
       "properties": [],
       "prices": {
-        "usd": "18.22"
+        "usd": "18.22",
+        "eur": "20.43",
+        "tix": null
       }
     },
     {
@@ -48156,7 +50244,9 @@
       "edhrec_rank": 10903,
       "properties": [],
       "prices": {
-        "usd": "0.37"
+        "usd": "0.37",
+        "eur": "0.47",
+        "tix": "0.04"
       }
     },
     {
@@ -48197,7 +50287,9 @@
       "edhrec_rank": 72,
       "properties": [],
       "prices": {
-        "usd": "57.76"
+        "usd": "57.76",
+        "eur": "31.65",
+        "tix": "0.11"
       }
     },
     {
@@ -48238,7 +50330,9 @@
       "edhrec_rank": 442,
       "properties": [],
       "prices": {
-        "usd": "0.92"
+        "usd": "0.92",
+        "eur": "1.45",
+        "tix": "0.03"
       }
     },
     {
@@ -48295,7 +50389,9 @@
       "edhrec_rank": 4557,
       "properties": [],
       "prices": {
-        "usd": "0.54"
+        "usd": "0.54",
+        "eur": "0.13",
+        "tix": "0.03"
       }
     },
     {
@@ -48366,7 +50462,9 @@
       "edhrec_rank": 831,
       "properties": [],
       "prices": {
-        "usd": "17.45"
+        "usd": "17.45",
+        "eur": "9.63",
+        "tix": null
       }
     },
     {
@@ -48437,7 +50535,9 @@
       "edhrec_rank": 835,
       "properties": [],
       "prices": {
-        "usd": "4.90"
+        "usd": "4.90",
+        "eur": "4.50",
+        "tix": null
       }
     },
     {
@@ -48493,7 +50593,9 @@
       "edhrec_rank": 121,
       "properties": [],
       "prices": {
-        "usd": "40.67"
+        "usd": "40.67",
+        "eur": "38.01",
+        "tix": "14.96"
       }
     },
     {
@@ -48564,7 +50666,9 @@
       "edhrec_rank": 821,
       "properties": [],
       "prices": {
-        "usd": "13.77"
+        "usd": "13.77",
+        "eur": "11.13",
+        "tix": null
       }
     },
     {
@@ -48607,7 +50711,9 @@
       "edhrec_rank": 2412,
       "properties": [],
       "prices": {
-        "usd": "22.06"
+        "usd": "22.06",
+        "eur": "20.36",
+        "tix": "7.24"
       }
     },
     {
@@ -48650,7 +50756,9 @@
       "edhrec_rank": 1675,
       "properties": [],
       "prices": {
-        "usd": "10.26"
+        "usd": "10.26",
+        "eur": "11.24",
+        "tix": "0.42"
       }
     },
     {
@@ -48720,7 +50828,9 @@
       "edhrec_rank": 516,
       "properties": [],
       "prices": {
-        "usd": "15.72"
+        "usd": "15.72",
+        "eur": "11.57",
+        "tix": "0.77"
       }
     },
     {
@@ -48762,7 +50872,9 @@
       "edhrec_rank": 1379,
       "properties": [],
       "prices": {
-        "usd": "16.10"
+        "usd": "16.10",
+        "eur": "9.02",
+        "tix": "0.12"
       }
     },
     {
@@ -48809,7 +50921,9 @@
       "edhrec_rank": 1701,
       "properties": [],
       "prices": {
-        "usd": "0.92"
+        "usd": "0.92",
+        "eur": "0.92",
+        "tix": "0.02"
       }
     },
     {
@@ -48879,7 +50993,9 @@
       "edhrec_rank": 6178,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -48924,7 +51040,9 @@
       "edhrec_rank": 169,
       "properties": [],
       "prices": {
-        "usd": "16.21"
+        "usd": "16.21",
+        "eur": "14.83",
+        "tix": "7.74"
       }
     },
     {
@@ -48968,7 +51086,9 @@
       "edhrec_rank": 450,
       "properties": [],
       "prices": {
-        "usd": "1.06"
+        "usd": "1.06",
+        "eur": "1.38",
+        "tix": "0.02"
       }
     },
     {
@@ -49011,7 +51131,9 @@
       "edhrec_rank": 607,
       "properties": [],
       "prices": {
-        "usd": "4.52"
+        "usd": "4.52",
+        "eur": "1.83",
+        "tix": "4.31"
       }
     },
     {
@@ -49056,7 +51178,9 @@
       "edhrec_rank": 25116,
       "properties": [],
       "prices": {
-        "usd": "0.20"
+        "usd": "0.20",
+        "eur": "0.16",
+        "tix": "0.04"
       }
     },
     {
@@ -49101,7 +51225,9 @@
       "edhrec_rank": 5505,
       "properties": [],
       "prices": {
-        "usd": "0.22"
+        "usd": "0.22",
+        "eur": "0.11",
+        "tix": "0.03"
       }
     },
     {
@@ -49145,7 +51271,9 @@
       "edhrec_rank": 28562,
       "properties": [],
       "prices": {
-        "usd": "1.20"
+        "usd": "1.20",
+        "eur": "0.98",
+        "tix": null
       }
     },
     {
@@ -49182,7 +51310,9 @@
       "edhrec_rank": 47,
       "properties": [],
       "prices": {
-        "usd": "32.55"
+        "usd": "32.55",
+        "eur": "21.48",
+        "tix": "1.38"
       }
     },
     {
@@ -49226,7 +51356,9 @@
       "edhrec_rank": 986,
       "properties": [],
       "prices": {
-        "usd": "0.74"
+        "usd": "0.74",
+        "eur": "0.79",
+        "tix": "1.21"
       }
     },
     {
@@ -49265,7 +51397,9 @@
       "edhrec_rank": 904,
       "properties": [],
       "prices": {
-        "usd": "5.44"
+        "usd": "5.44",
+        "eur": "3.71",
+        "tix": "0.02"
       }
     },
     {
@@ -49289,7 +51423,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.19",
+        "eur": "0.11",
+        "tix": null
       }
     },
     {
@@ -49335,7 +51471,9 @@
       "edhrec_rank": 537,
       "properties": [],
       "prices": {
-        "usd": "0.39"
+        "usd": "0.39",
+        "eur": "0.33",
+        "tix": "0.02"
       }
     },
     {
@@ -49380,7 +51518,9 @@
       "edhrec_rank": 729,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.28",
+        "tix": "0.15"
       }
     },
     {
@@ -49441,7 +51581,9 @@
       "edhrec_rank": 7907,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.15",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -49487,7 +51629,9 @@
       "edhrec_rank": 7016,
       "properties": [],
       "prices": {
-        "usd": "1.53"
+        "usd": "1.53",
+        "eur": "0.15",
+        "tix": "0.03"
       }
     },
     {
@@ -49533,7 +51677,9 @@
       "edhrec_rank": 4295,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.15",
+        "tix": "0.03"
       }
     },
     {
@@ -49579,7 +51725,9 @@
       "edhrec_rank": 4311,
       "properties": [],
       "prices": {
-        "usd": "0.41"
+        "usd": "0.41",
+        "eur": "0.16",
+        "tix": "0.03"
       }
     },
     {
@@ -49625,7 +51773,9 @@
       "edhrec_rank": 6084,
       "properties": [],
       "prices": {
-        "usd": "0.89"
+        "usd": "0.89",
+        "eur": "0.30",
+        "tix": "0.03"
       }
     },
     {
@@ -49671,7 +51821,9 @@
       "edhrec_rank": 5723,
       "properties": [],
       "prices": {
-        "usd": "0.40"
+        "usd": "0.40",
+        "eur": "0.19",
+        "tix": "0.03"
       }
     },
     {
@@ -49729,7 +51881,9 @@
       "edhrec_rank": 2499,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.20",
+        "tix": "0.03"
       }
     },
     {
@@ -49774,7 +51928,9 @@
       "edhrec_rank": 4828,
       "properties": [],
       "prices": {
-        "usd": "0.89"
+        "usd": "0.89",
+        "eur": "1.28",
+        "tix": "0.03"
       }
     },
     {
@@ -49818,7 +51974,9 @@
       "edhrec_rank": 346,
       "properties": [],
       "prices": {
-        "usd": null
+        "usd": null,
+        "eur": "10577.40",
+        "tix": null
       }
     },
     {
@@ -49879,7 +52037,9 @@
       "edhrec_rank": 2390,
       "properties": [],
       "prices": {
-        "usd": "0.28"
+        "usd": "0.28",
+        "eur": "0.27",
+        "tix": "0.02"
       }
     },
     {
@@ -49922,7 +52082,9 @@
       "edhrec_rank": 2800,
       "properties": [],
       "prices": {
-        "usd": "111.90"
+        "usd": "111.90",
+        "eur": "68.02",
+        "tix": "16.88"
       }
     },
     {
@@ -49966,7 +52128,9 @@
       "edhrec_rank": 7533,
       "properties": [],
       "prices": {
-        "usd": "0.36"
+        "usd": "0.36",
+        "eur": "0.18",
+        "tix": "0.02"
       }
     },
     {
@@ -50011,7 +52175,9 @@
       "edhrec_rank": 13987,
       "properties": [],
       "prices": {
-        "usd": "1.76"
+        "usd": "1.76",
+        "eur": "1.60",
+        "tix": "0.02"
       }
     },
     {
@@ -50052,7 +52218,9 @@
       "edhrec_rank": 148,
       "properties": [],
       "prices": {
-        "usd": "5.33"
+        "usd": "5.33",
+        "eur": "3.26",
+        "tix": "6.55"
       }
     },
     {
@@ -50093,7 +52261,9 @@
       "edhrec_rank": 7732,
       "properties": [],
       "prices": {
-        "usd": "0.33"
+        "usd": "0.33",
+        "eur": "0.12",
+        "tix": "0.03"
       }
     },
     {
@@ -50134,7 +52304,9 @@
       "edhrec_rank": 1189,
       "properties": [],
       "prices": {
-        "usd": "55.16"
+        "usd": "55.16",
+        "eur": "45.27",
+        "tix": "27.79"
       }
     },
     {
@@ -50179,7 +52351,9 @@
       "edhrec_rank": 1125,
       "properties": [],
       "prices": {
-        "usd": "11.75"
+        "usd": "11.75",
+        "eur": "8.18",
+        "tix": "0.15"
       }
     },
     {
@@ -50224,7 +52398,9 @@
       "edhrec_rank": 6574,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.05",
+        "tix": "0.03"
       }
     },
     {
@@ -50269,7 +52445,9 @@
       "edhrec_rank": 1102,
       "properties": [],
       "prices": {
-        "usd": "1.81"
+        "usd": "1.81",
+        "eur": "1.50",
+        "tix": "0.02"
       }
     },
     {
@@ -50342,7 +52520,9 @@
       "edhrec_rank": 1382,
       "properties": [],
       "prices": {
-        "usd": "0.42"
+        "usd": "0.42",
+        "eur": "0.63",
+        "tix": "0.03"
       }
     },
     {
@@ -50387,7 +52567,9 @@
       "edhrec_rank": 22992,
       "properties": [],
       "prices": {
-        "usd": "0.21"
+        "usd": "0.21",
+        "eur": "0.13",
+        "tix": "0.03"
       }
     },
     {
@@ -50432,7 +52614,9 @@
       "edhrec_rank": 52,
       "properties": [],
       "prices": {
-        "usd": "18.17"
+        "usd": "18.17",
+        "eur": "12.05",
+        "tix": "0.06"
       }
     },
     {
@@ -50535,7 +52719,9 @@
       "edhrec_rank": 1427,
       "properties": [],
       "prices": {
-        "usd": "3.57"
+        "usd": "3.57",
+        "eur": "1.20",
+        "tix": "0.02"
       }
     },
     {
@@ -50567,7 +52753,9 @@
       "is_basic": false,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.26",
+        "eur": "0.19",
+        "tix": "0.03"
       }
     },
     {
@@ -50625,7 +52813,9 @@
       "edhrec_rank": 13123,
       "properties": [],
       "prices": {
-        "usd": "0.09"
+        "usd": "0.09",
+        "eur": "0.06",
+        "tix": "0.03"
       }
     },
     {
@@ -50670,7 +52860,9 @@
       "edhrec_rank": 1184,
       "properties": [],
       "prices": {
-        "usd": "8.43"
+        "usd": "8.43",
+        "eur": "6.57",
+        "tix": "0.03"
       }
     },
     {
@@ -50714,7 +52906,9 @@
       "edhrec_rank": 992,
       "properties": [],
       "prices": {
-        "usd": "0.23"
+        "usd": "0.23",
+        "eur": "0.07",
+        "tix": "0.03"
       }
     },
     {
@@ -50758,7 +52952,9 @@
       "edhrec_rank": 648,
       "properties": [],
       "prices": {
-        "usd": "1.08"
+        "usd": "1.08",
+        "eur": "0.45",
+        "tix": "0.02"
       }
     },
     {
@@ -50798,7 +52994,9 @@
       "edhrec_rank": 7756,
       "properties": [],
       "prices": {
-        "usd": "31.64"
+        "usd": "31.64",
+        "eur": "13.41",
+        "tix": "2.09"
       }
     },
     {
@@ -50835,7 +53033,9 @@
       "edhrec_rank": 46,
       "properties": [],
       "prices": {
-        "usd": "88.41"
+        "usd": "88.41",
+        "eur": "36.94",
+        "tix": "7.33"
       }
     },
     {
@@ -50880,7 +53080,9 @@
       "edhrec_rank": 5607,
       "properties": [],
       "prices": {
-        "usd": "0.19"
+        "usd": "0.19",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     },
     {
@@ -50921,7 +53123,9 @@
       "edhrec_rank": 26651,
       "properties": [],
       "prices": {
-        "usd": "0.42"
+        "usd": "0.42",
+        "eur": "0.41",
+        "tix": "0.11"
       }
     },
     {
@@ -50963,7 +53167,9 @@
       "edhrec_rank": 2445,
       "properties": [],
       "prices": {
-        "usd": "10.50"
+        "usd": "10.50",
+        "eur": "4.10",
+        "tix": "0.04"
       }
     },
     {
@@ -51035,7 +53241,9 @@
       "edhrec_rank": 323,
       "properties": [],
       "prices": {
-        "usd": "3.02"
+        "usd": "3.02",
+        "eur": "4.46",
+        "tix": "0.93"
       }
     },
     {
@@ -51076,7 +53284,9 @@
       "edhrec_rank": 1086,
       "properties": [],
       "prices": {
-        "usd": "13.01"
+        "usd": "13.01",
+        "eur": "10.16",
+        "tix": "2.17"
       }
     },
     {
@@ -51118,7 +53328,9 @@
       "edhrec_rank": 868,
       "properties": [],
       "prices": {
-        "usd": "0.96"
+        "usd": "0.96",
+        "eur": "0.74",
+        "tix": "0.03"
       }
     },
     {
@@ -51166,7 +53378,9 @@
       "edhrec_rank": 6699,
       "properties": [],
       "prices": {
-        "usd": "0.27"
+        "usd": "0.27",
+        "eur": "0.08",
+        "tix": "0.03"
       }
     },
     {
@@ -51214,7 +53428,9 @@
       "edhrec_rank": 26327,
       "properties": [],
       "prices": {
-        "usd": "0.30"
+        "usd": "0.30",
+        "eur": "0.18",
+        "tix": null
       }
     },
     {
@@ -51260,7 +53476,9 @@
       "edhrec_rank": 2018,
       "properties": [],
       "prices": {
-        "usd": "16.64"
+        "usd": "16.64",
+        "eur": "9.26",
+        "tix": "0.02"
       }
     },
     {
@@ -51297,7 +53515,9 @@
       "edhrec_rank": 48,
       "properties": [],
       "prices": {
-        "usd": "108.94"
+        "usd": "108.94",
+        "eur": "63.63",
+        "tix": "7.09"
       }
     },
     {
@@ -51342,7 +53562,9 @@
       "edhrec_rank": 1724,
       "properties": [],
       "prices": {
-        "usd": "0.26"
+        "usd": "0.26",
+        "eur": "0.23",
+        "tix": "0.03"
       }
     },
     {
@@ -51387,7 +53609,9 @@
       "edhrec_rank": 114,
       "properties": [],
       "prices": {
-        "usd": "1.23"
+        "usd": "1.23",
+        "eur": "1.29",
+        "tix": "0.02"
       }
     },
     {
@@ -51432,7 +53656,9 @@
       "edhrec_rank": 2854,
       "properties": [],
       "prices": {
-        "usd": "0.59"
+        "usd": "0.59",
+        "eur": "0.64",
+        "tix": "0.03"
       }
     },
     {
@@ -51477,7 +53703,9 @@
       "edhrec_rank": 5063,
       "properties": [],
       "prices": {
-        "usd": "0.12"
+        "usd": "0.12",
+        "eur": "0.13",
+        "tix": "0.03"
       }
     },
     {
@@ -51527,7 +53755,9 @@
       "edhrec_rank": 468,
       "properties": [],
       "prices": {
-        "usd": "13.82"
+        "usd": "13.82",
+        "eur": "10.79",
+        "tix": "0.12"
       }
     },
     {
@@ -51572,7 +53802,9 @@
       "edhrec_rank": 134,
       "properties": [],
       "prices": {
-        "usd": "33.19"
+        "usd": "33.19",
+        "eur": "17.64",
+        "tix": "7.55"
       }
     },
     {
@@ -51615,7 +53847,9 @@
       "edhrec_rank": 3768,
       "properties": [],
       "prices": {
-        "usd": "75.21"
+        "usd": "75.21",
+        "eur": "49.54",
+        "tix": "0.57"
       }
     },
     {
@@ -51656,7 +53890,9 @@
       "edhrec_rank": 75,
       "properties": [],
       "prices": {
-        "usd": "15.68"
+        "usd": "15.68",
+        "eur": "9.94",
+        "tix": "0.07"
       }
     },
     {
@@ -51705,7 +53941,9 @@
       "edhrec_rank": 402,
       "properties": [],
       "prices": {
-        "usd": "25.69"
+        "usd": "25.69",
+        "eur": "16.92",
+        "tix": "0.06"
       }
     },
     {
@@ -51784,7 +54022,9 @@
       "edhrec_rank": 4108,
       "properties": [],
       "prices": {
-        "usd": "0.81"
+        "usd": "0.81",
+        "eur": "0.48",
+        "tix": "0.02"
       }
     },
     {
@@ -51827,7 +54067,9 @@
       "edhrec_rank": 2594,
       "properties": [],
       "prices": {
-        "usd": "0.38"
+        "usd": "0.38",
+        "eur": "0.28",
+        "tix": "0.03"
       }
     },
     {
@@ -51877,7 +54119,9 @@
       "edhrec_rank": 510,
       "properties": [],
       "prices": {
-        "usd": "10.64"
+        "usd": "10.64",
+        "eur": "9.42",
+        "tix": "0.06"
       }
     },
     {
@@ -51936,7 +54180,9 @@
       "edhrec_rank": 7347,
       "properties": [],
       "prices": {
-        "usd": "0.34"
+        "usd": "0.34",
+        "eur": "0.24",
+        "tix": "0.03"
       }
     },
     {
@@ -52006,7 +54252,9 @@
       "edhrec_rank": 9512,
       "properties": [],
       "prices": {
-        "usd": "0.15"
+        "usd": "0.15",
+        "eur": "0.14",
+        "tix": "0.03"
       }
     }
   ]

--- a/js/populator.js
+++ b/js/populator.js
@@ -10,12 +10,23 @@ let filteredData = []; // Declare the filteredData variable
 let selectedCards = localStorage.getItem('selectedCards') || [];
 let maxCardSelected = 100;
 
+let minPrice = parseInt(localStorage.getItem('minPrice')) || 0;
+let maxPrice = localStorage.getItem('maxPrice') !== null ? parseInt(localStorage.getItem('maxPrice')) : 1000;
+let currentCurrency = localStorage.getItem('currency') || 'usd';
+let showPrices = localStorage.getItem('showPrices') === 'true';
+
 function createCardElement(card) {
   const cardElement = $(`
     <!-- Card -->
     <div class="card" data-card-id="${card.id}" data-card-name="${card.name}" data-colors="${card.color_identity}" data-properties="${card.properties}" data-rank="${card.edhrec_rank}" data-basic="${card.is_basic}" tabindex="0"></div>
     <!-- End Card -->
   `);
+
+  let symbol = '$';
+  if (currentCurrency === 'eur') symbol = '€';
+  if (currentCurrency === 'tix') symbol = 'TIX ';
+  const price = card.prices?.[currentCurrency] || '—';
+  const priceDisplay = `<span class="card-price ${showPrices ? '' : 'hidden'}">${symbol}${price}</span>`;
 
   if (card.is_basic) {
       cardElement.html(`
@@ -24,6 +35,7 @@ function createCardElement(card) {
             <img loading="eager" src="${card.image_uris.normal}" alt="${card.name}" aria-oracle="${card.name}. It reads: ${card.oracle_text || ''}">
           </div>
         </div>
+        ${priceDisplay}
         <span class="cardName">${card.name}</span>
         <button type="button hidden" title="Remove  ${card.name}" tabindex="-1" class="remove-basic-button" style="--hiddenCount: 12;">—</button>
         <span class="totalBasics"></span>
@@ -46,6 +58,7 @@ function createCardElement(card) {
             <img class="front" loading="eager" src="${frontImageSrc}" alt="${frontImageAlt}" aria-oracle="${frontAriaOracle}">
           </div>
         </div>
+        ${priceDisplay}
         <span class="cardName">${card.name}</span>
         <button type="button hidden" title="Transform" tabindex="-1" class="flip-button" style="--hiddenCount: 12;"></button>
       `);
@@ -66,6 +79,7 @@ function createCardElement(card) {
             <img loading="eager" src="${mainImageSrc}" alt="${mainImageAlt}" aria-oracle="${mainAriaOracle}">
           </div>
         </div>
+        ${priceDisplay}
         <span class="cardName">${card.name}</span>
       `);
   }
@@ -151,6 +165,14 @@ function loadCards() {
         compA = (typeof a.edhrec_rank === 'number' && !isNaN(a.edhrec_rank)) ? a.edhrec_rank : Number.MAX_SAFE_INTEGER;
         compB = (typeof b.edhrec_rank === 'number' && !isNaN(b.edhrec_rank)) ? b.edhrec_rank : Number.MAX_SAFE_INTEGER;
         comparison = compA - compB;
+      } else if (sortingKey === 'cheapest') {
+        compA = parseFloat(a.prices?.[currentCurrency]) || 0;
+        compB = parseFloat(b.prices?.[currentCurrency]) || 0;
+        comparison = compA - compB;
+      } else if (sortingKey === 'expensive') {
+        compA = parseFloat(a.prices?.[currentCurrency]) || 0;
+        compB = parseFloat(b.prices?.[currentCurrency]) || 0;
+        comparison = compB - compA;
       } else {
         compA = String(a[sortingKey] || '').toLowerCase();
         compB = String(b[sortingKey] || '').toLowerCase();
@@ -221,6 +243,14 @@ function loadCards() {
           compB = (typeof b.edhrec_rank === 'number' && !isNaN(b.edhrec_rank)) ? b.edhrec_rank : Number.MAX_SAFE_INTEGER;
           comparison = compA - compB;
         }
+      } else if (sortingKey === 'cheapest') {
+        compA = parseFloat(a.prices?.[currentCurrency]) || 0;
+        compB = parseFloat(b.prices?.[currentCurrency]) || 0;
+        comparison = compA - compB;
+      } else if (sortingKey === 'expensive') {
+        compA = parseFloat(a.prices?.[currentCurrency]) || 0;
+        compB = parseFloat(b.prices?.[currentCurrency]) || 0;
+        comparison = compB - compA;
       } else {
         compA = String(a[sortingKey] || '').toLowerCase();
         compB = String(b[sortingKey] || '').toLowerCase();
@@ -318,8 +348,17 @@ function filterCards() {
       return selectedColors.includes(color);
     });
 
+    // Price filtering
+    let matchesPrice = true;
+    const cardPrice = parseFloat(card.prices?.[currentCurrency]) || 0;
+    if (maxPrice >= 1000) {
+      matchesPrice = cardPrice >= minPrice;
+    } else {
+      matchesPrice = cardPrice >= minPrice && cardPrice <= maxPrice;
+    }
 
-    return matchesSearch && (isSubset || showCard);
+
+    return matchesSearch && (isSubset || showCard) && matchesPrice;
   });
 
   startIndex = 0;
@@ -376,6 +415,21 @@ const updateFiltersFromUrl = () => {
     const value = checkbox.val();
     checkbox.prop('checked', selectedProperties.includes(value));
   });
+
+  const urlCurrency = queryParams.get('cur');
+  if (urlCurrency) {
+    currentCurrency = urlCurrency;
+    $(`input[name="currency"][value="${currentCurrency}"]`).prop('checked', true);
+  }
+
+  const urlMinPrice = queryParams.get('min');
+  const urlMaxPrice = queryParams.get('max');
+  if (urlMinPrice !== null && urlMaxPrice !== null) {
+    minPrice = parseInt(urlMinPrice);
+    maxPrice = parseInt(urlMaxPrice);
+    $("#price-slider").slider("values", [minPrice, maxPrice]);
+    updatePriceLabel();
+  }
 };
 
   
@@ -401,6 +455,16 @@ const updateUrlFromFilters = () => {
 
   if (selectedProperties.length > 0) {
     queryParams.set('properties', selectedProperties.join(','));
+  }
+
+  if (currentCurrency !== 'usd') {
+    queryParams.set('cur', currentCurrency);
+  }
+  if (minPrice > 0) {
+    queryParams.set('min', minPrice);
+  }
+  if (maxPrice < 1000) {
+    queryParams.set('max', maxPrice);
   }
 
   const newUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${queryParams.toString()}${window.location.hash}`;
@@ -450,7 +514,7 @@ const updateMobileColorFilters = () => {
 // Check if the data is already stored in localStorage
 const storedData = localStorage.getItem('landsData');
 const storedVersion = localStorage.getItem('landsDataVersion');
-const currentVersion = '10.03'; // [VERSION]
+const currentVersion = '10.04'; // [VERSION]
 
 if (!storedVersion) {
     console.log('No data found.');
@@ -535,6 +599,71 @@ $('.color, .property, .sorting').on('change', function() {
   updateUrlFromFilters();
   updateBasicCardsCount();
 });
+
+// Price Filter Toggle
+$('#price-filter-toggle').on('click', function() {
+  $('#priceFilters').toggleClass('hidden');
+});
+
+// Currency Selection
+$('input[name="currency"]').on('change', function() {
+  currentCurrency = $(this).val();
+  localStorage.setItem('currency', currentCurrency);
+  filterCards();
+  updateUrlFromFilters();
+  updateBasicCardsCount();
+});
+
+// Show Prices Toggle
+$('#show-prices').on('change', function() {
+  showPrices = $(this).is(':checked');
+  localStorage.setItem('showPrices', showPrices);
+  $('.card-price').toggleClass('hidden', !showPrices);
+  filterCards();
+});
+
+// Initialize Price Slider
+$(function() {
+  $("#price-slider").slider({
+    range: true,
+    min: 0,
+    max: 1000,
+    values: [minPrice, maxPrice],
+    slide: function(event, ui) {
+      minPrice = ui.values[0];
+      maxPrice = ui.values[1];
+      updatePriceLabel();
+    },
+    change: function(event, ui) {
+      minPrice = ui.values[0];
+      maxPrice = ui.values[1];
+      localStorage.setItem('minPrice', minPrice);
+      localStorage.setItem('maxPrice', maxPrice);
+      filterCards();
+      updateUrlFromFilters();
+    }
+  });
+
+  // Set initial UI state from variables (which were loaded from localStorage)
+  $(`input[name="currency"][value="${currentCurrency}"]`).prop('checked', true);
+  $('#show-prices').prop('checked', showPrices);
+
+  updatePriceLabel();
+});
+
+function updatePriceLabel() {
+  let symbol = '$';
+  if (currentCurrency === 'eur') symbol = '€';
+  if (currentCurrency === 'tix') symbol = 'TIX ';
+
+  if (minPrice === 0 && maxPrice >= 1000) {
+    $('.price-filter-label').text('Price: Any');
+  } else {
+    let label = `${symbol}${minPrice} - ${symbol}${maxPrice}`;
+    if (maxPrice >= 1000) label = `${symbol}${minPrice}+`;
+    $('.price-filter-label').text(label);
+  }
+}
 
 $('#isAdded').on('change', function() {
   const isChecked = $(this).is(':checked');

--- a/scripts/update-lands.js
+++ b/scripts/update-lands.js
@@ -83,10 +83,12 @@ async function main() {
                     updated = true;
                 }
                 if (!originalCard.prices) originalCard.prices = {};
-                if (originalCard.prices.usd !== scryfallCard.prices.usd) {
-                    originalCard.prices.usd = scryfallCard.prices.usd;
-                    updated = true;
-                }
+                ['usd', 'eur', 'tix'].forEach(curr => {
+                    if (originalCard.prices[curr] !== scryfallCard.prices[curr]) {
+                        originalCard.prices[curr] = scryfallCard.prices[curr];
+                        updated = true;
+                    }
+                });
                 if (updated) updatedCount++;
             }
         });
@@ -104,7 +106,9 @@ async function main() {
         updatedLandsData.forEach(card => {
             if (basicLandOrder.includes(card.name)) {
                 if (!card.prices) card.prices = {};
-                card.prices.usd = "0.00"; // Changed to string to match common Scryfall format if needed, or 0
+                card.prices.usd = "0.00";
+                card.prices.eur = "0.00";
+                card.prices.tix = "0.00";
             }
         });
 


### PR DESCRIPTION
This PR introduces a comprehensive price filtering system for the buffet/explore page. Users can now filter cards by a price range (0-1000+) in USD, EUR, or TIX. The system remembers user preferences across sessions and via shareable URLs. Additionally, cards can now display their current price in the selected currency, and new sorting options for price have been added.

---
*PR created automatically by Jules for task [10555492898546545150](https://jules.google.com/task/10555492898546545150) started by @NirDine*